### PR TITLE
docs: add road-map baseline governance files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this repository are tracked here.
+
+## [Unreleased]
+
+- Added baseline governance, legal, and security docs required for docs-only repo
+  standardization.
+- Added `NFR.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, and `docs/adrs/`
+  to align the planning repo with active org conventions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ All notable changes to this repository are tracked here.
   standardization.
 - Added `NFR.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, and `docs/adrs/`
   to align the planning repo with active org conventions.
+- Added a concrete private security reporting address to the security policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to road-map
+
+## 1. Purpose
+
+`road-map` tracks planning, governance workflows, and release guidance for
+Plasius. This file captures contribution expectations.
+
+## 2. How to Contribute
+
+- Open an issue in this repo for planning or process changes before major updates.
+- Keep changes small and clearly scoped.
+- Update `docs/` and release artifacts in the same PR as any process or
+  governance doc changes.
+- Keep ADRs and templates in sync with actual execution practices.
+
+## 3. Local Workflow
+
+Before proposing changes:
+
+1. Confirm the issue links to an owning feature/story where applicable.
+2. Update relevant documentation and scripts.
+3. Validate markdown or script changes locally before opening PRs.
+
+## 4. Required Checks
+
+For docs-only and workflow repos, required checks are:
+
+- `npm` is not used here; run applicable markdown reviews and consistency checks.
+- Ensure all links resolve and referenced templates remain up to date.
+- Preserve backward compatibility with existing graph governance and release templates.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2026 Plasius LTD
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NFR.md
+++ b/NFR.md
@@ -1,0 +1,29 @@
+# Non-Functional Requirements for `road-map`
+
+## 1. Purpose
+
+This document records non-functional expectations for the planning repository.
+
+## 2. Security and Privacy
+
+- No secrets, credentials, private credentials, or operational tokens are allowed in
+  tracked documentation.
+- Ensure links to external governance resources are reviewed for trust and integrity.
+
+## 3. Reliability
+
+- Governance documents must remain deterministic and versionable.
+- Templates and release notes should stay consistent and reproducible across
+  iterations.
+- Changes should preserve existing template compatibility unless explicitly
+  versioned.
+
+## 4. Accessibility and Comprehensibility
+
+- Docs should remain readable, structured, and navigable.
+- ADRs should include a decision context and consequence notes for traceability.
+
+## 5. Rollout Control
+
+- Repository baseline work aligns to parent feature governance:
+  `platform.repo-hardening-sweep.enabled`.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ Cross-repository planning and delivery tracking for Plasius packages.
 
 - Active cross-repo execution board:
   - [Plasius-LTD Project #1](https://github.com/orgs/Plasius-LTD/projects/1)
+
+## Governance and contribution docs
+
+- Contribution guide: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- Security policy: [`SECURITY.md`](./SECURITY.md)
+- Non-functional requirements: [`NFR.md`](./NFR.md)
+- Changelog: [`CHANGELOG.md`](./CHANGELOG.md)
+- Release license: [`LICENSE`](./LICENSE)
+- ADR index: [`docs/adrs/index.md`](./docs/adrs/index.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting Security Issues
+
+For security-related concerns in `road-map`:
+
+- Do not include vulnerable details in public issues or pull requests.
+- Contact maintainers privately before opening a public report.
+
+## Security Priorities for this Repo
+
+- Keep planning and governance docs free from secrets and tokens.
+- Keep release and capability guidance aligned with current platform security policy.
+- Remove exposed credentials from history or references immediately if found.
+
+## Scope
+
+`road-map` stores process and planning assets. Treat process docs and templates as
+potentially sensitive until reviewed by the relevant working group.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,8 @@
 For security-related concerns in `road-map`:
 
 - Do not include vulnerable details in public issues or pull requests.
-- Contact maintainers privately before opening a public report.
+- Email [security@plasius.co.uk](mailto:security@plasius.co.uk) with a concise
+  private report before opening a public issue.
 
 ## Security Priorities for this Repo
 

--- a/docs/adrs/adr-0001-road-map-baseline-alignment.md
+++ b/docs/adrs/adr-0001-road-map-baseline-alignment.md
@@ -1,0 +1,24 @@
+# ADR-0001: Baseline alignment for planning repository governance
+
+## Status
+
+Accepted
+
+## Context
+
+`road-map` functions as a process and planning repository and previously lacked
+standard baseline governance files expected across repo families.
+
+## Decision
+
+- Add missing baseline files (`CHANGELOG.md`, `CONTRIBUTING.md`,
+  `SECURITY.md`, `LICENSE`, `NFR.md`) and a minimal ADR index/docs scaffold to
+  establish explicit governance.
+- Keep all additions additive and non-functional with no behavior impact.
+
+## Consequences
+
+- Planning docs now have explicit operational expectations and release-safety
+  checks for future changes.
+- Review and onboarding paths are explicit and easier to validate during future
+  audits.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,0 +1,5 @@
+# ADR Index
+
+## Governance ADRs
+
+- [ADR 0001: Road-map docs repo baseline and governance alignment](./adr-0001-road-map-baseline-alignment.md)


### PR DESCRIPTION
## Summary

Implemented baseline governance documentation required for `road-map` to match repo standards.

## Scope

- Added `CHANGELOG.md`
- Added `CONTRIBUTING.md`
- Added `SECURITY.md`
- Added `LICENSE`
- Added `NFR.md`
- Added `docs/adrs/index.md`
- Added `docs/adrs/adr-0001-road-map-baseline-alignment.md`
- Updated `README.md` governance links
