### PR TITLE
[codex] Preserve local work from codex-preserve-road-map-feature-f358-road-map-baseli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this repository are tracked here.
 
 ## [Unreleased]
 
+- Added a high-level game service bridge gap document covering the missing layer
+  between account/profile services and gameplay runtime systems.
+- Added ADRs and TDRs for character lifecycle, world entry, authoritative
+  character state, game unlocks, party presence, external authorities, Identity
+  Card projection, observed-event projection, and AI authority-bridge planning.
+- Added a compact tree/table hierarchy view for active-development game systems
+  and their current parent/child planning relationships.
+- Added a canonical game systems inventory covering documentation, ticket
+  coverage, implementation depth, and current gaps across gameplay, scene, and
+  GPU package families.
+- Added a draft missing-issue set for central planning issues and repo tasks
+  needed to close the main game runtime integration gaps.
 - Added baseline governance, legal, and security docs required for docs-only repo
   standardization.
 - Added `NFR.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`, and `docs/adrs/`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Cross-repository planning and delivery tracking for Plasius packages.
 
+## Game Systems Planning
+
+- Canonical cross-repo inventory for the current game implementation audit:
+  - [`docs/game-systems-inventory.md`](./docs/game-systems-inventory.md)
+- Compact hierarchy view of active-development game systems:
+  - [`docs/game-systems-hierarchy.md`](./docs/game-systems-hierarchy.md)
+- High-level service-to-game bridge gap document:
+  - [`docs/game-service-bridge-gaps.md`](./docs/game-service-bridge-gaps.md)
+- Draft issue set for missing planning and integration coverage:
+  - [`docs/game-systems-missing-issue-drafts.md`](./docs/game-systems-missing-issue-drafts.md)
+
 ## Graph Package Rollout Governance
 
 - Release governance + compatibility matrix:
@@ -24,3 +35,4 @@ Cross-repository planning and delivery tracking for Plasius packages.
 - Changelog: [`CHANGELOG.md`](./CHANGELOG.md)
 - Release license: [`LICENSE`](./LICENSE)
 - ADR index: [`docs/adrs/index.md`](./docs/adrs/index.md)
+- TDR index: [`docs/tdrs/index.md`](./docs/tdrs/index.md)

--- a/docs/adrs/adr-0002-character-lifecycle-system-boundary.md
+++ b/docs/adrs/adr-0002-character-lifecycle-system-boundary.md
@@ -1,0 +1,36 @@
+# ADR-0002: Character lifecycle system as a dedicated bridge boundary
+
+## Status
+
+Proposed
+
+## Context
+
+The platform already supports account identity and profile management, while the
+game canon expects a playable character lifecycle with stage-aware path
+confirmation before normal gameplay progression.
+
+The current audited gap is the absence of a dedicated bridge boundary between:
+
+- signed-in account/profile identity
+- playable character identity
+- active character selection before gameplay/world entry
+
+## Decision
+
+- Introduce a dedicated Character Lifecycle System between account/profile
+  services and gameplay runtime entry.
+- Keep account identity separate from playable character identity.
+- Make this boundary responsible for character roster, character creation,
+  irreversible confirmation checkpoints, and active-character selection.
+- Keep gameplay runtime consumers downstream of an explicit active-character
+  handoff rather than reading profile state directly.
+
+## Consequences
+
+- The login-to-game funnel gains a clear intermediate step instead of jumping
+  straight from account/profile surfaces into runtime systems.
+- Character identity, roster ownership, and irreversible progression decisions
+  become easier to audit and evolve safely.
+- New contracts and service endpoints are required before world entry can be
+  treated as complete.

--- a/docs/adrs/adr-0003-world-entry-and-session-bootstrap-boundary.md
+++ b/docs/adrs/adr-0003-world-entry-and-session-bootstrap-boundary.md
@@ -1,0 +1,30 @@
+# ADR-0003: Authenticated world entry and session bootstrap as a distinct bridge system
+
+## Status
+
+Proposed
+
+## Context
+
+The game runtime needs an authenticated handoff from selected character identity
+into an active world/session context. The audit found runtime-facing scene
+surfaces, but no clear world-entry bridge that owns spawn, resume, or region
+bootstrap responsibilities.
+
+## Decision
+
+- Introduce a dedicated Authenticated World Entry and Session Bootstrap System.
+- Require world entry to consume an authenticated active-character context rather
+  than raw account/profile identity.
+- Make this boundary responsible for spawn, resume, region/world target
+  selection, and session bootstrap payload delivery into downstream runtime
+  consumers.
+- Keep scene/runtime and renderer consumers downstream of this session bootstrap
+  boundary rather than letting them infer entry state ad hoc.
+
+## Consequences
+
+- World-entry semantics become explicit and testable.
+- Continue-game, spawn, and resume flows can be implemented consistently.
+- Backend/runtime APIs need dedicated contracts rather than anonymous or
+  loosely-scoped runtime reads.

--- a/docs/adrs/adr-0004-authoritative-character-state-and-resume-boundary.md
+++ b/docs/adrs/adr-0004-authoritative-character-state-and-resume-boundary.md
@@ -1,0 +1,28 @@
+# ADR-0004: Authoritative character state and resume ownership stays outside local runtime stores
+
+## Status
+
+Proposed
+
+## Context
+
+The audit found runtime-local player-state constructs for inventory, equipment,
+skills, and effects, but not a clearly authoritative bridge service for durable
+character state persistence, checkpointing, and resume-safe restoration.
+
+## Decision
+
+- Introduce a dedicated Authoritative Character State, Inventory, and Resume
+  System.
+- Treat renderer-local or scene-local player stores as consumer-facing runtime
+  caches, not as the source of durable truth.
+- Persist canonical character state, inventory, equipment, effects, and resume
+  checkpoints in an authoritative service boundary.
+- Restore runtime-local state only from explicit authoritative payloads.
+
+## Consequences
+
+- Durable character truth becomes separate from local runtime state.
+- Save/load, resume, and re-entry flows gain clearer ownership.
+- Inventory, equipment, effect, and checkpoint contracts need explicit canonical
+  representations.

--- a/docs/adrs/adr-0005-game-capabilities-and-unlocks-boundary.md
+++ b/docs/adrs/adr-0005-game-capabilities-and-unlocks-boundary.md
@@ -1,0 +1,28 @@
+# ADR-0005: Game capabilities and unlocks require a character-scoped bridge service
+
+## Status
+
+Proposed
+
+## Context
+
+The account/profile plane already exposes capability and rollout controls, but
+the game side needs a parallel character-scoped answer for stage unlocks,
+institution eligibility, and gameplay surface access.
+
+## Decision
+
+- Introduce a dedicated Game Capabilities, Eligibility, and Unlocks System.
+- Scope this system to playable-character state, stage gates, institutional
+  readiness, and authority eligibility.
+- Keep rollout flags and player-character unlock truth separate, even when both
+  affect UI discoverability.
+- Require Player System and UI surfaces to preflight against this character
+  capability boundary before exposing gated actions.
+
+## Consequences
+
+- Character-state access rules become explicit instead of being inferred from
+  profile or UI state.
+- Discoverability and authorization flows gain a stable bridge contract.
+- New capability/read-model APIs are required for gameplay surfaces.

--- a/docs/adrs/adr-0006-party-presence-and-friendly-tracking-boundary.md
+++ b/docs/adrs/adr-0006-party-presence-and-friendly-tracking-boundary.md
@@ -1,0 +1,28 @@
+# ADR-0006: Party presence and friendly-tracking truth require a dedicated service boundary
+
+## Status
+
+Proposed
+
+## Context
+
+The game canon gives the Party System explicit responsibility for group
+membership, friendly-player tracking, and cooperative-state visibility, but the
+audit did not find a surrounding service that owns that truth.
+
+## Decision
+
+- Introduce a dedicated Party Membership, Presence, and Friendly-Tracking
+  System.
+- Treat party truth as a sibling service to Player System orchestration rather
+  than a child module hidden inside player guidance contracts.
+- Make this boundary responsible for membership truth, allied presence,
+  separation state, and condensed cooperative-state projections for runtime/UI
+  consumers.
+
+## Consequences
+
+- Friendly tracking and allied overlays gain an authoritative upstream source.
+- Cooperative runtime behavior can be implemented without inventing ad hoc local
+  truth.
+- Presence, membership, and separation semantics need dedicated contracts.

--- a/docs/adrs/adr-0007-external-authority-services-boundary.md
+++ b/docs/adrs/adr-0007-external-authority-services-boundary.md
@@ -1,0 +1,31 @@
+# ADR-0007: Guild, institution, and commerce authority remain external to the Player System
+
+## Status
+
+Proposed
+
+## Context
+
+The current canon already states that guild quests and institutional training are
+not owned by the Player System. The remaining audited gap is the lack of a
+cleanly named and planned bridge service layer for those external authorities,
+especially commerce.
+
+## Decision
+
+- Introduce an External Authority Services boundary for guild, institution, and
+  commerce ownership.
+- Keep guild quests externally authoritative and only synchronized into the
+  Player System after acceptance or state change.
+- Keep schools, barracks, academies, apprenticeships, and shops authoritative in
+  their own service flows rather than inside Player System state.
+- Use the Player System only as an orchestration, recommendation, and routing
+  layer across those authorities.
+
+## Consequences
+
+- External authorities remain distinct from guidance/orchestration.
+- Commerce and shop authority gain an explicit planning home instead of falling
+  through profile or runtime gaps.
+- Cross-service contract work is required to link Player System guidance to
+  real institutional and commercial truth.

--- a/docs/adrs/adr-0008-identity-card-projection-boundary.md
+++ b/docs/adrs/adr-0008-identity-card-projection-boundary.md
@@ -1,0 +1,26 @@
+# ADR-0008: Identity Card projection requires a dedicated runtime-facing service boundary
+
+## Status
+
+Proposed
+
+## Context
+
+The technical and lore baselines expect Identity Card projection surfaces for
+players and world objects, while the audit did not find a dedicated service that
+owns authoritative projection into runtime/UI consumers.
+
+## Decision
+
+- Introduce an Identity Card Projection and Runtime Status System.
+- Treat identity-card projections as runtime-facing views over authoritative
+  character and world truth, not as a new truth source.
+- Make this boundary responsible for bounded disclosure, projection shaping, and
+  runtime-readable status delivery for self, allies, and valid targets.
+
+## Consequences
+
+- Identity System surfaces gain a stable upstream source.
+- Bounded disclosure rules can be centralized instead of spread across runtime
+  consumers.
+- New projection models and delivery APIs are required.

--- a/docs/adrs/adr-0009-observed-event-achievement-and-gossip-boundary.md
+++ b/docs/adrs/adr-0009-observed-event-achievement-and-gossip-boundary.md
@@ -1,0 +1,29 @@
+# ADR-0009: Observed-event projection, achievements, and gossip share one bridge pipeline
+
+## Status
+
+Proposed
+
+## Context
+
+The canon already defines a blob-backed observed-event processing model for
+player recall, achievement projection, and gossip sourcing. The audited gap is
+that the surrounding platform plane is still more mature for profile/account
+service traffic than for gameplay event projection traffic.
+
+## Decision
+
+- Treat Observed-Event Projection, Achievement, and Gossip as one bridge
+  pipeline rather than three isolated service systems.
+- Make this boundary responsible for ingestion, normalization, compaction,
+  player-safe projection, and curated read-model delivery.
+- Keep hidden server-only truth out of player-facing recall, achievement, and
+  gossip exports.
+
+## Consequences
+
+- The event-to-read-model pipeline gains one explicit service home.
+- Gameplay recall and achievement work can evolve without overloading account or
+  analytics-only surfaces.
+- Storage-backed processing, timer triggers, and projection APIs need explicit
+  operational ownership.

--- a/docs/adrs/adr-0010-ai-authority-bridge-boundary.md
+++ b/docs/adrs/adr-0010-ai-authority-bridge-boundary.md
@@ -1,0 +1,32 @@
+# ADR-0010: AI dialogue, NPC action, and GM mediation require a bounded authority bridge
+
+## Status
+
+Proposed
+
+## Context
+
+The platform already has chatbot and `ai-game` surfaces, and the game canon
+expects AI-assisted NPC and governance behaviors. The audited gap is that there
+is no clearly bounded bridge between AI outputs and runtime-authoritative world
+mutation.
+
+## Decision
+
+- Introduce a dedicated AI authority bridge between AI/chatbot outputs and
+  runtime/world authorities.
+- Treat AI outputs as advisory unless they pass deterministic checks or an
+  explicit operator gate.
+- Keep generic chatbot surfaces separate from authoritative NPC/world mutation
+  paths.
+- Require runtime-facing contracts to translate approved AI outputs into bounded
+  gameplay authority requests.
+
+## Consequences
+
+- AI-driven NPC dialogue and GM-style mediation gain one explicit trust
+  boundary.
+- World/runtime systems keep deterministic control over authoritative
+  mutations.
+- Additional mediation contracts, auditability, and policy checks are required
+  before AI outputs can influence gameplay state.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -3,3 +3,15 @@
 ## Governance ADRs
 
 - [ADR 0001: Road-map docs repo baseline and governance alignment](./adr-0001-road-map-baseline-alignment.md)
+
+## Game Service Bridge ADRs
+
+- [ADR 0002: Character lifecycle system as a dedicated bridge boundary](./adr-0002-character-lifecycle-system-boundary.md)
+- [ADR 0003: Authenticated world entry and session bootstrap as a distinct bridge system](./adr-0003-world-entry-and-session-bootstrap-boundary.md)
+- [ADR 0004: Authoritative character state and resume ownership stays outside local runtime stores](./adr-0004-authoritative-character-state-and-resume-boundary.md)
+- [ADR 0005: Game capabilities and unlocks require a character-scoped bridge service](./adr-0005-game-capabilities-and-unlocks-boundary.md)
+- [ADR 0006: Party presence and friendly-tracking truth require a dedicated service boundary](./adr-0006-party-presence-and-friendly-tracking-boundary.md)
+- [ADR 0007: Guild, institution, and commerce authority remain external to the Player System](./adr-0007-external-authority-services-boundary.md)
+- [ADR 0008: Identity Card projection requires a dedicated runtime-facing service boundary](./adr-0008-identity-card-projection-boundary.md)
+- [ADR 0009: Observed-event projection, achievements, and gossip share one bridge pipeline](./adr-0009-observed-event-achievement-and-gossip-boundary.md)
+- [ADR 0010: AI dialogue, NPC action, and GM mediation require a bounded authority bridge](./adr-0010-ai-authority-bridge-boundary.md)

--- a/docs/game-service-bridge-gaps.md
+++ b/docs/game-service-bridge-gaps.md
@@ -1,0 +1,227 @@
+# Game Service Bridge Gaps
+
+## Purpose
+
+This document captures the missing bridge systems between the existing
+account/profile service plane and the in-game runtime systems already being
+planned and implemented.
+
+- Audit date: `2026-05-15`
+- Related game inventory:
+  - [`game-systems-inventory.md`](./game-systems-inventory.md)
+  - [`game-systems-hierarchy.md`](./game-systems-hierarchy.md)
+  - [`game-systems-missing-issue-drafts.md`](./game-systems-missing-issue-drafts.md)
+
+## Current Transition Problem
+
+The current platform already has meaningful surrounding services:
+
+- account/session identity through `@plasius/auth`
+- profile/settings and avatar flows through `@plasius/profile`
+- account/profile graph rollouts in `plasius-ltd-site`
+- generic API, storage, analytics, graph, and translation services
+
+The game side already has meaningful runtime planning:
+
+- Player System orchestration
+- scene/runtime composition
+- renderer and `gpu-*` runtime families
+- external authority package boundaries for spellcraft, item crafting, and
+  dungeon crafting
+
+The missing layer is the bridge between those two planes.
+
+In practice, the current flow is still much closer to:
+
+`auth -> account/profile -> game runtime`
+
+The target flow needs to be closer to:
+
+`auth -> account/profile -> character lifecycle -> world/session bootstrap -> authoritative character/world state -> gameplay runtime`
+
+## Missing Systems Summary
+
+| Missing system | Main bridge role | Current upstream plane | Current downstream plane |
+| --- | --- | --- | --- |
+| Character Lifecycle System | Move from account identity to playable character identity | `auth`, `profile`, account graph | Player System, world entry, progression |
+| Authenticated World Entry and Session Bootstrap System | Move from selected character into an active world/runtime session | character lifecycle, auth/session | scene runtime, renderer, Player System |
+| Authoritative Character State, Inventory, and Resume System | Persist and restore durable game state | world entry, profile linkage, ledgers | Player System, renderer, crafting, quests |
+| Game Capabilities, Eligibility, and Unlocks System | Expose what the current character may access right now | auth/profile, character state, progression truth | Player System, UI, external authority systems |
+| Party Membership, Presence, and Friendly-Tracking System | Provide party truth and allied state handoffs | character/session state | Party overlays, route cues, cooperative play |
+| External Authority Services for Guild, Institution, and Commerce | Provide non-Player-System authority surfaces | character state, stage unlocks, social context | guild quests, training, shops, crafting handoff |
+| Identity Card Projection and Runtime Status System | Project authoritative character/object state into runtime-readable surfaces | character/world state, entity truth | Identity System, target overlays, scene/runtime |
+| Observed-Event Projection, Achievement, and Gossip Pipeline | Convert raw observed events into player-facing read models | gameplay event ingestion, storage, timers | Event Log, achievements, gossip, Player System recall |
+| AI Dialogue, NPC Action, and GM Authority Bridge System | Bound AI outputs before they can affect authoritative game state | `chatbot`, `ai-game`, governance/evals | NPC dialogue, GM mediation, world/runtime authorities |
+
+## Gap Details
+
+### 1. Character Lifecycle System
+
+Problem:
+
+- Account and profile identity already exist, but there is no dedicated bridge
+  system for character roster, character creation, character selection, and
+  active-character ownership.
+- The game canon expects deterministic path confirmation, feature selection,
+  name, gender, and social-form lock before normal social gameplay.
+
+Bridge responsibility:
+
+- list playable characters for the signed-in account
+- create a new playable character or draft
+- confirm irreversible character choices at the correct stage
+- select the active character for continuation into gameplay
+
+### 2. Authenticated World Entry and Session Bootstrap System
+
+Problem:
+
+- The current backend/runtime shape exposes scene runtime data, but there is no
+  dedicated authenticated handoff from selected character to active world
+  session, spawn context, or resume flow.
+
+Bridge responsibility:
+
+- accept an authenticated active character
+- choose or validate target world/session/region context
+- establish spawn, resume, or re-entry context
+- hand authoritative session bootstrap data into scene/runtime consumers
+
+### 3. Authoritative Character State, Inventory, and Resume System
+
+Problem:
+
+- The runtime has local player-state constructs, but the audit did not find a
+  clearly authoritative service for durable character state, inventory,
+  equipment, effects, checkpoints, or resume-safe restoration.
+
+Bridge responsibility:
+
+- persist canonical character state and checkpoints
+- persist inventory and equipment truth
+- restore state safely on world entry and resume
+- separate local renderer state from durable authoritative state
+
+### 4. Game Capabilities, Eligibility, and Unlocks System
+
+Problem:
+
+- The account/profile plane already uses capability and rollout surfaces, but
+  the game side lacks an equivalent service layer for stage-gated character
+  unlocks, institution eligibility, and runtime surface access.
+
+Bridge responsibility:
+
+- answer what the current character may access now
+- express stage unlocks, institution readiness, and authority eligibility
+- support Player System preflight and UI discoverability
+- keep reversible rollout and player-state gating distinct
+
+### 5. Party Membership, Presence, and Friendly-Tracking System
+
+Problem:
+
+- The game canon defines party membership, friendly tracking, and allied alerts,
+  but the surrounding service plane does not yet provide party truth, party
+  presence, or cooperative-state delivery.
+
+Bridge responsibility:
+
+- own party membership truth
+- publish party presence and separation state
+- expose allied status needed by Party/System overlays
+- support shared-objective routing and cooperative visibility
+
+### 6. External Authority Services for Guild, Institution, and Commerce
+
+Problem:
+
+- The Player System properly does not own guild, school, barracks, academy, or
+  shop authority, but the service-plane bridge into those authorities is still
+  incomplete and uneven.
+
+Bridge responsibility:
+
+- keep guild quests externally authoritative
+- model admission and readiness into schools, barracks, academies, and
+  apprenticeships
+- provide shop and commerce authority surfaces
+- keep Player System orchestration separate from institutional authority truth
+
+### 7. Identity Card Projection and Runtime Status System
+
+Problem:
+
+- Canon expects runtime-visible Identity Card projections for players and world
+  objects, but there is no clearly named surrounding service that owns the
+  authoritative projection feed into runtime/UI consumers.
+
+Bridge responsibility:
+
+- project authoritative character and world-object status into runtime-friendly
+  identity-card shapes
+- support self-status, target inspection, and bounded disclosure
+- keep projection separate from underlying world truth sources
+
+### 8. Observed-Event Projection, Achievement, and Gossip Pipeline
+
+Problem:
+
+- The canon clearly describes a blob-backed observed-event lake and projected
+  read models, but the surrounding implemented service plane is still much more
+  mature for account/profile traffic than for gameplay event projection traffic.
+
+Bridge responsibility:
+
+- ingest observed gameplay events
+- normalize and compact them in storage-backed processing flows
+- project Event Log, achievement, and gossip-facing read models
+- expose player-safe reads without leaking server-only truth
+
+### 9. AI Dialogue, NPC Action, and GM Authority Bridge System
+
+Problem:
+
+- AI packages and chatbot surfaces exist, but there is no clearly bounded bridge
+  that mediates AI-generated NPC dialogue, AI-suggested NPC actions, or
+  GM-style world interventions before runtime-authoritative systems accept them.
+
+Bridge responsibility:
+
+- accept bounded AI outputs from chatbot and `ai-game` style workflows
+- classify which outputs are advisory, deterministic-checkable, or
+  operator-gated
+- translate valid outputs into runtime-safe authority requests
+- prevent generic AI surfaces from becoming de facto world authority
+
+## Priority Order
+
+Recommended first delivery order:
+
+1. Character Lifecycle System
+2. Authenticated World Entry and Session Bootstrap System
+3. Authoritative Character State, Inventory, and Resume System
+4. Game Capabilities, Eligibility, and Unlocks System
+5. Party Membership, Presence, and Friendly-Tracking System
+6. External Authority Services for Guild, Institution, and Commerce
+7. Identity Card Projection and Runtime Status System
+8. Observed-Event Projection, Achievement, and Gossip Pipeline
+9. AI Dialogue, NPC Action, and GM Authority Bridge System
+
+## Ticket Mapping
+
+Central bridge epic:
+
+- `Plasius-LTD/plasius-ltd-site#555` `[EPIC] Service-to-game bridge systems between account identity and gameplay runtime`
+
+| System | Coverage type | Issue mapping |
+| --- | --- | --- |
+| Character Lifecycle System | new | `Plasius-LTD/plasius-ltd-site#559`, `Plasius-LTD/plasius-ltd-site#563`, `Plasius-LTD/plasius-ltd-site#567` |
+| Authenticated World Entry and Session Bootstrap System | new | `Plasius-LTD/plasius-ltd-site#571`, `Plasius-LTD/plasius-ltd-site#574`, `Plasius-LTD/plasius-ltd-site#578` |
+| Authoritative Character State, Inventory, and Resume System | new | `Plasius-LTD/plasius-ltd-site#582`, `Plasius-LTD/plasius-ltd-site#586`, `Plasius-LTD/plasius-ltd-site#591` |
+| Game Capabilities, Eligibility, and Unlocks System | new plus related existing training-state coverage | `Plasius-LTD/plasius-ltd-site#595`, `Plasius-LTD/plasius-ltd-site#599`, `Plasius-LTD/plasius-ltd-site#602`, related `Plasius-LTD/plasius-ltd-site#408` |
+| Party Membership, Presence, and Friendly-Tracking System | new plus related existing overlay coverage | `Plasius-LTD/plasius-ltd-site#606`, `Plasius-LTD/plasius-ltd-site#610`, `Plasius-LTD/plasius-ltd-site#614`, related `Plasius-LTD/plasius-ltd-site#416` |
+| External Authority Services for Guild, Institution, and Commerce | new commerce bridge coverage plus reused guild and institution coverage | new `Plasius-LTD/plasius-ltd-site#617`, `Plasius-LTD/plasius-ltd-site#621`, `Plasius-LTD/plasius-ltd-site#625`; reused `Plasius-LTD/plasius-ltd-site#382`, `Plasius-LTD/plasius-ltd-site#390`, `Plasius-LTD/plasius-ltd-site#398`, `Plasius-LTD/plasius-ltd-site#421`, `Plasius-LTD/plasius-ltd-site#422`, `Plasius-LTD/plasius-ltd-site#423`, `Plasius-LTD/plasius-ltd-site#424`, `Plasius-LTD/plasius-ltd-site#425`, `Plasius-LTD/plasius-ltd-site#426`, `Plasius-LTD/plasius-ltd-site#427`, `Plasius-LTD/plasius-ltd-site#431` |
+| Identity Card Projection and Runtime Status System | new authority-bridge coverage plus reused downstream overlay coverage | new `Plasius-LTD/plasius-ltd-site#628`, `Plasius-LTD/plasius-ltd-site#632`, `Plasius-LTD/plasius-ltd-site#636`; reused `Plasius-LTD/plasius-ltd-site#388`, `Plasius-LTD/plasius-ltd-site#396` |
+| Observed-Event Projection, Achievement, and Gossip Pipeline | reused existing open coverage | `Plasius-LTD/plasius-ltd-site#383`, `Plasius-LTD/plasius-ltd-site#391`, `Plasius-LTD/plasius-ltd-site#399`, `Plasius-LTD/plasius-ltd-site#445` |
+| AI Dialogue, NPC Action, and GM Authority Bridge System | new bridge coverage plus related prior AI-contract coverage | new `Plasius-LTD/plasius-ltd-site#640`, `Plasius-LTD/plasius-ltd-site#644`, `Plasius-LTD/plasius-ltd-site#648`; related `Plasius-LTD/plasius-ltd-site#266` |

--- a/docs/game-systems-hierarchy.md
+++ b/docs/game-systems-hierarchy.md
@@ -1,0 +1,102 @@
+# Game Systems Hierarchy
+
+## Purpose
+
+This is the compact tree/table view of the primary game systems currently in
+active development.
+
+- Audit basis: [`game-systems-inventory.md`](./game-systems-inventory.md)
+- Scope: primary game systems only
+- Excluded from this quick view: supporting packages previously reviewed but not
+  counted as primary game systems, such as `environment`, `sharedassets`,
+  `sharedcomponents`, and `video`
+
+## Completion Rule
+
+Bold system names indicate systems considered complete for the current game
+implementation scope.
+
+Under the current audit threshold, no active-development system is fully
+complete yet. Every system below still has at least one material documentation,
+tracking, ownership, or integration gap, so no entries are bolded.
+
+## Tree
+
+- Game Runtime
+  - Player Guidance and Authority Systems
+    - `player-system`
+      - `ai-game`
+      - `spellcraft`
+      - `item-crafting`
+      - `dungeon-crafting`
+      - `player-system-interface`
+        - `player-system-demo-viewer`
+        - `voice`
+  - World and Scene Composition Systems
+    - `gpu-world-generator`
+      - `entity-manager`
+      - `scene-layout`
+      - `scene-object`
+      - `scene-animation`
+      - `scene-runtime`
+  - Rendering and Runtime Infrastructure
+    - `renderer`
+      - `shadow`
+      - `gpu-renderer`
+      - `gpu-camera`
+      - `gpu-physics`
+      - `gpu-lighting`
+      - `gpu-fluid`
+      - `gpu-cloth`
+      - `gpu-particles`
+      - `gpu-performance`
+      - `gpu-worker`
+      - `gpu-xr`
+      - `gpu-shared`
+
+## Table
+
+| System | Parent | Direct children | Complete | Notes |
+| --- | --- | --- | --- | --- |
+| `player-system` | Player Guidance and Authority Systems | `ai-game`, `spellcraft`, `item-crafting`, `dungeon-crafting`, `player-system-interface` | No | Core orchestration boundary for player guidance and external authority handoffs |
+| `ai-game` | `player-system` | None | No | AI event, gossip, and feedback contracts feeding the gameplay layer |
+| `spellcraft` | `player-system` | None | No | External spellcraft authority boundary guided by the Player System |
+| `item-crafting` | `player-system` | None | No | External item-crafting authority boundary guided by the Player System |
+| `dungeon-crafting` | `player-system` | None | No | External dungeon-crafting authority boundary guided by the Player System |
+| `player-system-interface` | `player-system` | `player-system-demo-viewer`, `voice` | No | Interface-facing overlay and focus-pane contract layer |
+| `player-system-demo-viewer` | `player-system-interface` | None | No | Validation and scenario surface for Player System flows |
+| `voice` | `player-system-interface` | None | No | Voice intent and narrated interaction surface for gameplay/runtime targets |
+| `gpu-world-generator` | World and Scene Composition Systems | `entity-manager`, `scene-layout`, `scene-object`, `scene-animation`, `scene-runtime` | No | Upstream generated world data source for runtime composition |
+| `entity-manager` | `gpu-world-generator` | None | No | Canonical schema ownership for generated and runtime-owned entities |
+| `scene-layout` | `gpu-world-generator` | None | No | Zone and anchor layout contracts for runtime composition |
+| `scene-object` | `gpu-world-generator` | None | No | Object transform, bounds, and attachment contracts |
+| `scene-animation` | `gpu-world-generator` | None | No | Animation palette and playback contracts used by runtime composition |
+| `scene-runtime` | `gpu-world-generator` | None | No | Runtime composition layer combining scene manifests and palette resolution |
+| `renderer` | Rendering and Runtime Infrastructure | `shadow`, `gpu-renderer`, `gpu-camera`, `gpu-physics`, `gpu-lighting`, `gpu-fluid`, `gpu-cloth`, `gpu-particles`, `gpu-performance`, `gpu-worker`, `gpu-xr`, `gpu-shared` | No | Product-facing rendering host that binds scene/runtime inputs |
+| `shadow` | `renderer` | None | No | Rendering support utility layer with unresolved ownership/tracking lineage |
+| `gpu-renderer` | `renderer` | None | No | Framework-agnostic WebGPU renderer runtime seam beneath the product renderer |
+| `gpu-camera` | `renderer` | None | No | Camera planning and multiview control aligned to runtime focus state |
+| `gpu-physics` | `renderer` | None | No | Physics bridge feeding GPU runtime and scene motion surfaces |
+| `gpu-lighting` | `renderer` | None | No | Lighting kernels and planning profiles used by the GPU runtime |
+| `gpu-fluid` | `renderer` | None | No | Fluid representation, worker, and quality adaptation contracts |
+| `gpu-cloth` | `renderer` | None | No | Cloth representation, worker, and quality adaptation contracts |
+| `gpu-particles` | `renderer` | None | No | Particle effect bundles and worker manifests for gameplay and scene feedback |
+| `gpu-performance` | `renderer` | None | No | Performance governor coordinating quality ladders across GPU subsystems |
+| `gpu-worker` | `renderer` | None | No | Worker runtime and scheduling foundation for GPU jobs |
+| `gpu-xr` | `renderer` | None | No | XR session lifecycle and frame-rate negotiation layer |
+| `gpu-shared` | `renderer` | None | No | Shared validation/demo runtime and assets used by the GPU package family |
+
+## Notes on Parent/Child Semantics
+
+- These parent/child relationships reflect runtime and architectural ownership
+  direction for planning purposes, not strict npm dependency declarations.
+- `player-system-interface` is nested under `player-system` because it is the
+  outward presentation layer for Player System state.
+- `player-system-demo-viewer` and `voice` are nested under
+  `player-system-interface` because they are current interface-facing validation
+  and interaction surfaces.
+- `gpu-world-generator` is shown above the `scene-*` and `entity-manager`
+  family because the current planning gap is the world-to-scene handoff path.
+- `renderer` is shown above the `gpu-*` runtime family because the current
+  product-facing rendering host must bind the lower-level GPU runtimes into one
+  live scene.

--- a/docs/game-systems-inventory.md
+++ b/docs/game-systems-inventory.md
@@ -1,0 +1,247 @@
+# Game Systems Inventory
+
+## Purpose
+
+This document records the current state of Plasius game-related systems across
+documentation, GitHub tracking, and local implementation.
+
+- Audit date: `2026-05-15`
+- Scope: package repos in `/Users/philliphounslow/plasius` that directly
+  participate in gameplay, scene runtime, rendering/GPU runtime, or player
+  interaction for the current game implementation effort
+- Source types reviewed:
+  - repo-local `README.md`, ADR, TDR, and design docs
+  - package-repo GitHub issues
+  - obvious matching Epic/Feature/Story issues in
+    `Plasius-LTD/plasius-ltd-site`
+  - local source files to assess implementation depth
+
+This is a planning artifact. GitHub Project linkage and issue parent/child
+relationships still need final verification in GitHub before work execution.
+
+## Status Legend
+
+- `Strong`: active system-specific ticket coverage exists in the package repo
+  and/or the central planning repo
+- `Partial`: some ticket coverage exists, but it is thin, maintenance-heavy, or
+  missing on one side
+- `Weak`: ticket coverage is missing, unclear, or mostly maintenance-only
+- `Contract-first`: implementation is mostly types, factories, manifests, or
+  package boundary contracts
+- `Validation/composition`: validation and composition logic exist, but there is
+  no clear live runtime host integration yet
+- `Runtime shell`: executable adapters or loops exist, but end-to-end product
+  binding is still thin
+- `Runtime`: meaningful executable behavior exists beyond contracts or
+  validation
+- `Demo runtime`: meaningful executable behavior exists primarily in demos or
+  shared validation scenes
+
+## Core Gameplay Systems
+
+| System | Primary role | Documentation | Ticket coverage | Implementation depth | Current gap |
+| --- | --- | --- | --- | --- | --- |
+| `ai-game` | Game-domain AI events, gossip, and feedback contracts | README, 8 ADRs | Repo: Strong, Central: Partial | Contract-first | Needs real handoff and consumption paths from `player-system` and external authority packages |
+| `player-system` | Non-rendering guidance/orchestration boundary | README, ADR, TDR, design note | Repo: Strong, Central: Strong | Contract-first | Needs actual session orchestration, state transitions, and authority handoff behavior |
+| `player-system-interface` | Overlay and focus-pane interface contracts | README, ADR, TDR, design note | Repo: Partial, Central: Partial | Contract-first | Needs live 3D overlay host and runtime binding into scene/runtime surfaces |
+| `player-system-demo-viewer` | Demo scenario manifest surface | README, ADR, TDR, design note | Repo: Partial, Central: Partial | Contract-first | Needs end-to-end scenarios that exercise real system integration rather than bootstrap manifests only |
+| `spellcraft` | Academy-gated external authority boundary | README, ADR, TDR, design note | Repo: Partial, Central: Partial | Contract-first | Needs runtime authority workflow, Player System handoff, and gameplay-facing consumers |
+| `item-crafting` | Apprenticeship-gated external authority boundary | README, ADR, TDR, design note | Repo: Partial, Central: Partial | Contract-first | Needs runtime authority workflow, Player System handoff, and gameplay-facing consumers |
+| `dungeon-crafting` | DIS-gated external authority boundary | README, ADR, TDR, design note | Repo: Partial, Central: Partial | Contract-first | Needs runtime authority workflow, Player System handoff, and gameplay-facing consumers |
+
+## Scene and Runtime Systems
+
+| System | Primary role | Documentation | Ticket coverage | Implementation depth | Current gap |
+| --- | --- | --- | --- | --- | --- |
+| `entity-manager` | Canonical entity and asset schema library | README, 3 ADRs | Repo: Weak, Central: Weak | Runtime | Needs game-specific planning coverage for generated world entities and runtime-owned scene objects |
+| `scene-layout` | Layout zones, anchors, and placement contracts | README, ADR | Repo: Partial, Central: Partial | Validation/composition | Needs live consumption by scene runtime and renderer hosts |
+| `scene-object` | Object transforms, bounds, and attachment contracts | README, ADR | Repo: Partial, Central: Partial | Validation/composition | Needs live consumption by world generation, runtime composition, and renderer hosts |
+| `scene-animation` | Animation palette manifests and playback state | README, ADR | Repo: Weak, Central: Partial | Validation/composition | Needs active implementation planning beyond package bootstrap and validation |
+| `scene-runtime` | Runtime composition and palette resolution | README, ADR | Repo: Partial, Central: Partial | Validation/composition | Needs a live host that composes real layout, object, palette, and overlay inputs together |
+| `renderer` | Product-facing renderer package | README, 2 ADRs, TDR, design note | Repo: Partial, Central: Partial | Runtime | Needs binding to scene runtime composition and Player System overlays |
+| `shadow` | Lighting and shadow utilities | README, 2 ADRs | Repo: Weak or unclear, Central: Weak | Runtime shell | GitHub repo ownership is unclear; needs explicit ownership and tracking alignment |
+| `voice` | Voice intent routing and controls | README, 2 ADRs | Repo: Partial, Central: Partial | Runtime | Needs combat-safe runtime integration with Player System focus panes and scene targets |
+
+## GPU and Rendering Runtime Systems
+
+| System | Primary role | Documentation | Ticket coverage | Implementation depth | Current gap |
+| --- | --- | --- | --- | --- | --- |
+| `gpu-renderer` | Framework-agnostic WebGPU renderer runtime | README, 5 ADRs, 4 TDRs, 2 design notes | Repo: Partial, Central: Partial | Runtime shell | Needs explicit central planning for how it binds into the product runtime rather than demos and package shells |
+| `gpu-world-generator` | GPU-assisted terrain/world generation | README, 5 ADRs, 2 TDRs, design note | Repo: Partial, Central: Weak | Runtime | Needs central feature/story coverage and a defined handoff into `entity-manager` and `scene-runtime` |
+| `gpu-physics` | Physics bridge package | README, 5 ADRs, 3 TDRs, 2 design notes | Repo: Partial, Central: Partial | Runtime shell | Needs stronger live runtime planning beyond bridge and demo roles |
+| `gpu-lighting` | Lighting WGSL kernels and planning profiles | README, 6 ADRs, 3 TDRs, design note | Repo: Partial, Central: Partial | Runtime | Needs final product-runtime integration planning, but core system planning exists |
+| `gpu-camera` | Camera control and multiview planning | README, 2 ADRs | Repo: Weak, Central: Weak | Runtime shell | Needs central feature/story coverage and binding to focus/runtime state |
+| `gpu-fluid` | Fluid continuity planning and worker contracts | README, 4 ADRs, 4 TDRs, 3 design notes | Repo: Partial, Central: Partial | Runtime shell | Needs live runtime adoption beyond planning contracts and validation demos |
+| `gpu-cloth` | Cloth continuity planning and worker contracts | README, 4 ADRs, 4 TDRs, 3 design notes | Repo: Partial, Central: Partial | Runtime shell | Needs live runtime adoption beyond planning contracts and validation demos |
+| `gpu-particles` | Particle WGSL bundles and manifests | README, 4 ADRs, 3 TDRs, 2 design notes | Repo: Weak, Central: Weak | Runtime shell | Needs central coverage and gameplay-facing effect integration plans |
+| `gpu-performance` | GPU performance governor and quality ladders | README, 6 ADRs, 5 TDRs, 4 design notes | Repo: Partial, Central: Weak | Runtime | Needs central coverage and a live multi-system integration harness |
+| `gpu-shared` | Shared browser-safe demo runtime and assets | README, 4 ADRs, 2 TDRs, 2 design notes | Repo: Strong, Central: Strong | Demo runtime | Needs a clear boundary between shared validation runtime and product runtime ownership |
+| `gpu-worker` | Worker WGSL runtime and job scheduling | README, 7 ADRs, 5 TDRs, 2 design notes | Repo: Partial, Central: Partial | Runtime | Needs broader product integration planning, but the package scope is well established |
+| `gpu-xr` | XR session lifecycle and frame-rate negotiation | README, 3 ADRs, TDR, design note | Repo: Weak, Central: Weak | Runtime shell | Needs central coverage and explicit integration with camera and performance governance |
+
+## Supporting Packages Reviewed But Not Counted as Primary Game Systems
+
+These packages were reviewed as supporting dependencies or adjacent surfaces, but
+they are not the primary source of the current game-implementation gaps.
+
+| System | Note |
+| --- | --- |
+| `environment` | React environment context helpers; documented and implemented, but not a game system driver |
+| `sharedassets` | Shared asset library; useful for packaging, but not the main gameplay/runtime planning gap |
+| `sharedcomponents` | Shared React UI components; relevant to shell UX, but not the main game runtime gap |
+| `video` | Video generation package; adjacent to media tooling rather than core game runtime delivery |
+
+## Derived Views
+
+### Documented Systems
+
+Primary game systems with local documentation present:
+
+- `ai-game`
+- `player-system`
+- `player-system-interface`
+- `player-system-demo-viewer`
+- `spellcraft`
+- `item-crafting`
+- `dungeon-crafting`
+- `entity-manager`
+- `scene-layout`
+- `scene-object`
+- `scene-animation`
+- `scene-runtime`
+- `renderer`
+- `shadow`
+- `voice`
+- `gpu-renderer`
+- `gpu-world-generator`
+- `gpu-physics`
+- `gpu-lighting`
+- `gpu-camera`
+- `gpu-fluid`
+- `gpu-cloth`
+- `gpu-particles`
+- `gpu-performance`
+- `gpu-shared`
+- `gpu-worker`
+- `gpu-xr`
+
+### Systems With Active Package-Repo Tickets
+
+- `ai-game`
+- `player-system`
+- `player-system-interface`
+- `player-system-demo-viewer`
+- `spellcraft`
+- `item-crafting`
+- `dungeon-crafting`
+- `entity-manager`
+- `scene-layout`
+- `scene-object`
+- `scene-runtime`
+- `renderer`
+- `voice`
+- `gpu-renderer`
+- `gpu-world-generator`
+- `gpu-physics`
+- `gpu-lighting`
+- `gpu-camera`
+- `gpu-fluid`
+- `gpu-cloth`
+- `gpu-particles`
+- `gpu-performance`
+- `gpu-shared`
+- `gpu-worker`
+- `gpu-xr`
+
+Notable exceptions:
+
+- `scene-animation` has package history, but no active open issue at the moment
+- `shadow` package-repo tracking is unclear because the expected GitHub repo was
+  not resolvable during the audit
+
+### Systems With Clear Central Epic, Feature, or Story Coverage
+
+- `ai-game`
+- `player-system`
+- `player-system-interface`
+- `player-system-demo-viewer`
+- `spellcraft`
+- `item-crafting`
+- `dungeon-crafting`
+- `scene-layout`
+- `scene-object`
+- `scene-animation`
+- `scene-runtime`
+- `renderer`
+- `voice`
+- `gpu-renderer`
+- `gpu-physics`
+- `gpu-lighting`
+- `gpu-fluid`
+- `gpu-cloth`
+- `gpu-shared`
+- `gpu-worker`
+
+Weak or missing central coverage:
+
+- `entity-manager`
+- `shadow`
+- `gpu-world-generator`
+- `gpu-camera`
+- `gpu-particles`
+- `gpu-performance`
+- `gpu-xr`
+
+### Systems Already Implemented
+
+Implemented mostly as package boundaries or contracts:
+
+- `ai-game`
+- `player-system`
+- `player-system-interface`
+- `player-system-demo-viewer`
+- `spellcraft`
+- `item-crafting`
+- `dungeon-crafting`
+
+Implemented mostly as validation and composition layers:
+
+- `scene-layout`
+- `scene-object`
+- `scene-animation`
+- `scene-runtime`
+
+Implemented as deeper runtime, demo runtime, or system utilities:
+
+- `entity-manager`
+- `renderer`
+- `shadow`
+- `voice`
+- `gpu-renderer`
+- `gpu-world-generator`
+- `gpu-physics`
+- `gpu-lighting`
+- `gpu-camera`
+- `gpu-fluid`
+- `gpu-cloth`
+- `gpu-particles`
+- `gpu-performance`
+- `gpu-shared`
+- `gpu-worker`
+- `gpu-xr`
+
+## Gap Summary
+
+- The documentation estate is broad, but it is mostly package-local and does
+  not yet provide one canonical architecture view of the full game runtime.
+- The core gameplay packages are real and documented, but they are still mostly
+  boundary contracts instead of one connected gameplay loop.
+- The scene package family exists, but it is still primarily a manifest
+  validation and composition layer rather than a live integrated host runtime.
+- The GPU stack is the deepest implementation area, but several important
+  runtime systems still lack strong central planning coverage:
+  `gpu-world-generator`, `gpu-camera`, `gpu-particles`, `gpu-performance`,
+  `gpu-xr`, and likely `shadow`.
+- `gpu-shared` currently carries a lot of practical runtime value through demos,
+  which is useful for validation but risks hiding where product-runtime
+  ownership should actually live.

--- a/docs/game-systems-missing-issue-drafts.md
+++ b/docs/game-systems-missing-issue-drafts.md
@@ -1,0 +1,373 @@
+# Game Systems Missing Issue Drafts
+
+## Purpose
+
+This document drafts the missing issue set required to close the main planning
+gaps identified in [`game-systems-inventory.md`](./game-systems-inventory.md).
+
+Some central issue families described here may already have been created in
+GitHub after the initial draft was written. The document is retained as the
+original package/runtime draft set for broader follow-on work beyond the
+service-bridge planning slice captured in
+[`game-service-bridge-gaps.md`](./game-service-bridge-gaps.md).
+
+## Drafting Rules Applied
+
+- Central planning issues belong in `Plasius-LTD/plasius-ltd-site`
+- Repo implementation tasks belong in the repo where the code change will land
+- No standalone implementation task is proposed without a parent Feature
+- Existing coverage is reused where possible; this draft only fills the most
+  obvious missing gaps
+
+## Central Planning Issues for `Plasius-LTD/plasius-ltd-site`
+
+### 1. Epic
+
+- Title: `[EPIC] Integrated game runtime vertical slices across gameplay, scene, and GPU systems`
+- Why:
+  - The current game package family is documented and partially implemented, but
+    it is still split across contracts, validation layers, and demo runtimes.
+  - There is no single central Epic tying gameplay authorities, scene runtime,
+    and GPU runtime integration together.
+- Acceptance criteria:
+  - All child Features and Stories for the integration path are created and
+    linked
+  - The Epic clearly names the target vertical slices to deliver
+  - The Epic references the canonical inventory and follow-on design work
+
+### 2. Feature
+
+- Parent: `[EPIC] Integrated game runtime vertical slices across gameplay, scene, and GPU systems`
+- Title: `[FEATURE] Player System authority handoffs across AI, spellcraft, item-crafting, and dungeon-crafting`
+- Proposed feature flag: `isekai.player-system.authority-handoffs.enabled`
+- Why:
+  - `player-system`, `ai-game`, `spellcraft`, `item-crafting`, and
+    `dungeon-crafting` exist, but they are not yet planned as one integrated
+    authority-handoff feature.
+- Acceptance criteria:
+  - The Player System handoff model is defined at the feature level
+  - External authority boundaries and responsibilities are explicit
+  - Repo tasks exist for each affected package
+
+### 3. Story
+
+- Parent: `[FEATURE] Player System authority handoffs across AI, spellcraft, item-crafting, and dungeon-crafting`
+- Title: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Why:
+  - The current contracts exist per package, but the cross-package handshake is
+    not planned as one Story.
+- Acceptance criteria:
+  - Inputs and outputs across the five packages are enumerated
+  - Required state transitions and readiness descriptors are identified
+  - Repo tasks exist for `player-system`, `ai-game`, `spellcraft`,
+    `item-crafting`, and `dungeon-crafting`
+
+### 4. Story
+
+- Parent: `[FEATURE] Player System authority handoffs across AI, spellcraft, item-crafting, and dungeon-crafting`
+- Title: `[STORY] Present authority handoff state through Player System interface, demo validation, and voice surfaces`
+- Why:
+  - The interface and validation packages exist, but the integration plan for
+    runtime surfaces is still missing.
+- Acceptance criteria:
+  - Required overlay, demo, and voice surfaces are defined
+  - Combat-safe interaction constraints are explicit
+  - Repo tasks exist for `player-system-interface`,
+    `player-system-demo-viewer`, and `voice`
+
+### 5. Feature
+
+- Parent: `[EPIC] Integrated game runtime vertical slices across gameplay, scene, and GPU systems`
+- Title: `[FEATURE] World generation to scene runtime pipeline`
+- Proposed feature flag: `isekai.world-runtime-pipeline.enabled`
+- Why:
+  - `gpu-world-generator`, `entity-manager`, `scene-*`, and renderer packages
+    exist, but there is no central Feature that treats them as one pipeline.
+- Acceptance criteria:
+  - The world-to-scene pipeline boundaries are defined
+  - Manifest ownership is explicit across packages
+  - Repo tasks exist for each affected package
+
+### 6. Story
+
+- Parent: `[FEATURE] World generation to scene runtime pipeline`
+- Title: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Why:
+  - World generation has implementation depth, but the downstream scene/entity
+    handoff is not centrally planned.
+- Acceptance criteria:
+  - Generated terrain/object outputs are mapped to entity/runtime contracts
+  - Schema ownership is explicit
+  - Repo tasks exist for `gpu-world-generator`, `entity-manager`,
+    `scene-layout`, `scene-object`, `scene-animation`, and `scene-runtime`
+
+### 7. Story
+
+- Parent: `[FEATURE] World generation to scene runtime pipeline`
+- Title: `[STORY] Render composed runtime scenes through renderer and gpu-renderer integration seams`
+- Why:
+  - The composition and rendering packages exist, but the binding between them
+    is not fully tracked as a central Story.
+- Acceptance criteria:
+  - Product-runtime ownership is explicit between `renderer`, `gpu-renderer`,
+    and `gpu-shared`
+  - A live scene composition path is planned
+  - Repo tasks exist for `renderer`, `gpu-renderer`, and `gpu-shared`
+
+### 8. Feature
+
+- Parent: `[EPIC] Integrated game runtime vertical slices across gameplay, scene, and GPU systems`
+- Title: `[FEATURE] Runtime camera, performance, particles, and XR adaptation loop`
+- Proposed feature flag: `isekai.runtime.adaptation-loop.enabled`
+- Why:
+  - `gpu-camera`, `gpu-performance`, `gpu-particles`, and `gpu-xr` all exist,
+    but central product planning for the live frame loop is still missing.
+- Acceptance criteria:
+  - The runtime loop responsibilities are defined across the participating
+    packages
+  - Frame-budget and adaptation ownership are explicit
+  - Repo tasks exist for all affected packages
+
+### 9. Story
+
+- Parent: `[FEATURE] Runtime camera, performance, particles, and XR adaptation loop`
+- Title: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Why:
+  - The packages have meaningful internals, but the product integration plan is
+    still thin.
+- Acceptance criteria:
+  - Runtime loop touchpoints are enumerated
+  - Quality ladder and worker-budget hooks are defined
+  - Repo tasks exist for `gpu-camera`, `gpu-performance`, `gpu-particles`,
+    `gpu-worker`, `gpu-fluid`, and `gpu-cloth`
+
+### 10. Story
+
+- Parent: `[FEATURE] Runtime camera, performance, particles, and XR adaptation loop`
+- Title: `[STORY] Negotiate XR sessions against camera and performance budgets`
+- Why:
+  - XR support is documented and partially implemented, but not centrally
+    planned as part of the live runtime loop.
+- Acceptance criteria:
+  - XR session lifecycle responsibilities are explicit
+  - Camera and performance budget interactions are defined
+  - Repo tasks exist for `gpu-xr`, `gpu-camera`, and `gpu-performance`
+
+### 11. Feature
+
+- Parent: `[EPIC] Integrated game runtime vertical slices across gameplay, scene, and GPU systems`
+- Title: `[FEATURE] Rendering support package ownership and tracking alignment`
+- Proposed feature flag: `isekai.render-support-alignment.enabled`
+- Why:
+  - `shadow` is documented and implemented locally, but its repository ownership
+    and planning lineage are unclear.
+- Acceptance criteria:
+  - `shadow` ownership is resolved
+  - Its relationship to `renderer` and `gpu-lighting` is explicitly tracked
+  - Follow-on repo task ownership is clear
+
+### 12. Story
+
+- Parent: `[FEATURE] Rendering support package ownership and tracking alignment`
+- Title: `[STORY] Resolve shadow package ownership and its relationship to renderer and gpu-lighting`
+- Why:
+  - The package exists locally but the expected GitHub repo was not resolvable
+    during audit.
+- Acceptance criteria:
+  - The package either has a tracked repo, or its scope is deliberately merged
+    elsewhere
+  - Documentation and issue ownership are aligned
+
+## Repo Task Drafts
+
+### Player guidance and authority handoffs
+
+- Repository: `Plasius-LTD/player-system`
+- Parent story: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Title: `[TASK] Implement authoritative handoff descriptors, readiness state, and transition helpers for external authority packages`
+- Acceptance criteria:
+  - Handoff descriptors exist for `ai-game`, `spellcraft`, `item-crafting`, and
+    `dungeon-crafting`
+  - Transition helpers cover readiness, dispatch, and return state
+  - Tests cover the new transition and handoff surfaces
+
+- Repository: `Plasius-LTD/ai-game`
+- Parent story: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Title: `[TASK] Add Player System handoff event shapes and ingestion surfaces for external authority interactions`
+- Acceptance criteria:
+  - AI event contracts can represent inbound Player System handoffs
+  - Event ingestion surfaces distinguish authority source and outcome
+  - Tests cover the added contracts
+
+- Repository: `Plasius-LTD/spellcraft`
+- Parent story: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Title: `[TASK] Add Player System spellcraft handoff contracts for readiness, request, and result state`
+
+- Repository: `Plasius-LTD/item-crafting`
+- Parent story: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Title: `[TASK] Add Player System item-crafting handoff contracts for readiness, request, and result state`
+
+- Repository: `Plasius-LTD/dungeon-crafting`
+- Parent story: `[STORY] Define and validate Player System handoff contracts across external authority packages`
+- Title: `[TASK] Add Player System dungeon-crafting handoff contracts for readiness, request, and result state`
+
+### Interface, demo validation, and voice
+
+- Repository: `Plasius-LTD/player-system-interface`
+- Parent story: `[STORY] Present authority handoff state through Player System interface, demo validation, and voice surfaces`
+- Title: `[TASK] Bind authority handoff, focus, and target state into overlay and pane contracts`
+- Acceptance criteria:
+  - Overlay contracts represent handoff readiness and result state
+  - Focus and target bindings align with runtime scene anchors
+  - Tests cover new overlay and pane shapes
+
+- Repository: `Plasius-LTD/player-system-demo-viewer`
+- Parent story: `[STORY] Present authority handoff state through Player System interface, demo validation, and voice surfaces`
+- Title: `[TASK] Add end-to-end demo scenarios for authority handoffs, overlay updates, and combat-safe interaction flows`
+- Acceptance criteria:
+  - Demo scenarios exist for at least one handoff into each external authority
+  - Demo scenarios exercise overlay and voice-state changes
+  - Scenario manifests stay package-owned and testable
+
+- Repository: `Plasius-LTD/voice`
+- Parent story: `[STORY] Present authority handoff state through Player System interface, demo validation, and voice surfaces`
+- Title: `[TASK] Route combat-safe voice intents into Player System focus panes and scene interaction targets`
+- Acceptance criteria:
+  - Voice intents map onto Player System focus surfaces
+  - Combat-safe restrictions are explicit and testable
+  - Runtime targets can be addressed by stable identifiers
+
+### World generation to runtime composition
+
+- Repository: `Plasius-LTD/gpu-world-generator`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Emit generated terrain, object, and anchor outputs in entity-manager and scene-runtime compatible shapes`
+- Acceptance criteria:
+  - World outputs map cleanly into downstream schema and runtime contracts
+  - Generated objects include stable identifiers and attachment anchors
+  - Tests cover the published handoff shapes
+
+- Repository: `Plasius-LTD/entity-manager`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Add schemas for generated scene entities, anchors, and runtime-bound world objects`
+- Acceptance criteria:
+  - Generated scene entities and anchors have canonical schema ownership
+  - Runtime-facing generated object shapes serialize consistently
+  - Tests cover the new schemas
+
+- Repository: `Plasius-LTD/scene-layout`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Add world-generated zone and anchor layout contracts for runtime composition`
+
+- Repository: `Plasius-LTD/scene-object`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Add generated object, attachment, and target-anchor contracts for runtime composition`
+
+- Repository: `Plasius-LTD/scene-animation`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Add world-driven animation palette and playback state contracts for runtime composition`
+
+- Repository: `Plasius-LTD/scene-runtime`
+- Parent story: `[STORY] Bind generated world data into entity-manager and scene-runtime manifests`
+- Title: `[TASK] Compose generated layout, object, animation, and overlay manifests into a live runtime composition contract`
+- Acceptance criteria:
+  - Runtime composition accepts generated scene inputs
+  - Overlay and palette resolution seams are explicit
+  - Validation covers the new composition path
+
+### Renderer ownership and live scene hosting
+
+- Repository: `Plasius-LTD/renderer`
+- Parent story: `[STORY] Render composed runtime scenes through renderer and gpu-renderer integration seams`
+- Title: `[TASK] Mount scene-runtime composition and Player System overlays through renderer compositor helpers`
+- Acceptance criteria:
+  - Renderer consumes scene-runtime outputs without inventing new ownership
+  - Overlay composition hooks are explicit
+  - Tests or demos cover the scene-runtime binding path
+
+- Repository: `Plasius-LTD/gpu-renderer`
+- Parent story: `[STORY] Render composed runtime scenes through renderer and gpu-renderer integration seams`
+- Title: `[TASK] Define and expose gpu-renderer integration seams required by the product runtime host`
+- Acceptance criteria:
+  - Product-runtime integration seams are published
+  - Ownership boundaries with `renderer` are explicit
+  - Package docs name the expected runtime hooks
+
+- Repository: `Plasius-LTD/gpu-shared`
+- Parent story: `[STORY] Render composed runtime scenes through renderer and gpu-renderer integration seams`
+- Title: `[TASK] Isolate demo-runtime-only helpers from product-runtime integration seams`
+- Acceptance criteria:
+  - Demo-runtime helpers remain available
+  - Product-runtime ownership is not hidden inside shared demo code
+  - Docs make the distinction explicit
+
+### Runtime adaptation loop
+
+- Repository: `Plasius-LTD/gpu-camera`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Bind camera planning to runtime focus state, target anchors, and scene mode transitions`
+- Acceptance criteria:
+  - Camera planning responds to runtime focus and anchor changes
+  - The contract between camera state and scene/runtime state is explicit
+  - Tests or demos cover the live binding seam
+
+- Repository: `Plasius-LTD/gpu-performance`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Integrate performance governor outputs across renderer, worker, particles, cloth, fluid, and XR adapters in one runtime harness`
+- Acceptance criteria:
+  - One runtime harness exercises the adapter set together
+  - Budget and quality ownership stay explicit by domain
+  - Tests or demos prove the integration path
+
+- Repository: `Plasius-LTD/gpu-particles`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Add gameplay-facing particle bundles for spellcraft, combat, and world-event feedback`
+- Acceptance criteria:
+  - Published effect bundles map to gameplay/runtime events
+  - Particle manifests expose the required budget hooks
+  - Docs explain the gameplay-facing effect surface
+
+- Repository: `Plasius-LTD/gpu-worker`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Publish the worker-budget and scheduling hooks required by the live runtime adaptation loop`
+
+- Repository: `Plasius-LTD/gpu-fluid`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Expose live runtime quality and adaptation hooks for fluid representation changes`
+
+- Repository: `Plasius-LTD/gpu-cloth`
+- Parent story: `[STORY] Bind camera, GPU performance, particles, and worker budgets into the live frame loop`
+- Title: `[TASK] Expose live runtime quality and adaptation hooks for cloth representation changes`
+
+### XR negotiation
+
+- Repository: `Plasius-LTD/gpu-xr`
+- Parent story: `[STORY] Negotiate XR sessions against camera and performance budgets`
+- Title: `[TASK] Bind XR session negotiation and frame-rate hints to camera and GPU performance governance`
+- Acceptance criteria:
+  - XR runtime hints flow into the shared adaptation loop
+  - Session lifecycle hooks are stable and documented
+  - Tests or demos cover the coordination path
+
+## Deliberately Not Drafted Here as New Central Issues
+
+These systems already have clearer central coverage or the main gap is no longer
+"missing issues" but execution against existing issues. Some still appear above
+as linked repo-task drafts where they need to participate in a broader
+cross-system Story:
+
+- `spellcraft`
+- `item-crafting`
+- `dungeon-crafting`
+- `scene-layout`
+- `scene-object`
+- `scene-animation`
+- `scene-runtime`
+- `gpu-lighting`
+- `gpu-fluid`
+- `gpu-cloth`
+- `gpu-shared`
+- `gpu-worker`
+
+They still appear in repo-task drafts where cross-system integration work needs
+to be linked to a new parent Story.

--- a/docs/tdrs/index.md
+++ b/docs/tdrs/index.md
@@ -1,0 +1,13 @@
+# TDR Index
+
+## Game Service Bridge TDRs
+
+- [TDR 0001: Character lifecycle first implementation slice](./tdr-0001-character-lifecycle-first-slice.md)
+- [TDR 0002: World entry and session bootstrap first implementation slice](./tdr-0002-world-entry-and-session-bootstrap-first-slice.md)
+- [TDR 0003: Authoritative character state and resume first implementation slice](./tdr-0003-authoritative-character-state-first-slice.md)
+- [TDR 0004: Game capabilities and unlocks first implementation slice](./tdr-0004-game-capabilities-and-unlocks-first-slice.md)
+- [TDR 0005: Party presence and friendly-tracking first implementation slice](./tdr-0005-party-presence-first-slice.md)
+- [TDR 0006: External authority services first implementation slice](./tdr-0006-external-authority-services-first-slice.md)
+- [TDR 0007: Identity Card projection first implementation slice](./tdr-0007-identity-card-projection-first-slice.md)
+- [TDR 0008: Observed-event projection pipeline first implementation slice](./tdr-0008-observed-event-pipeline-first-slice.md)
+- [TDR 0009: AI authority bridge first implementation slice](./tdr-0009-ai-authority-bridge-first-slice.md)

--- a/docs/tdrs/tdr-0001-character-lifecycle-first-slice.md
+++ b/docs/tdrs/tdr-0001-character-lifecycle-first-slice.md
@@ -1,0 +1,31 @@
+# TDR-0001: Character lifecycle first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first delivery slice for character roster, creation, irreversible
+confirmation checkpoints, and active-character selection.
+
+## First Slice
+
+- list playable characters for the signed-in account
+- create a character draft or new playable character
+- confirm the active character before world entry
+- reserve explicit fields for stage-aware irreversible decisions
+- expose one stable active-character selection result for downstream world entry
+
+## Out of Scope
+
+- full progression logic after world entry
+- combat/runtime state mutation
+- party, guild, or institution authority
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- supporting schema work is likely in `entity-manager`
+- auth/profile flows remain upstream dependencies, not the owner of character
+  lifecycle truth

--- a/docs/tdrs/tdr-0002-world-entry-and-session-bootstrap-first-slice.md
+++ b/docs/tdrs/tdr-0002-world-entry-and-session-bootstrap-first-slice.md
@@ -1,0 +1,29 @@
+# TDR-0002: World entry and session bootstrap first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first authenticated bridge from selected character identity into
+world/session bootstrap payloads consumed by runtime systems.
+
+## First Slice
+
+- accept authenticated active-character input
+- validate target world/session selection rules
+- support spawn or resume bootstrap shape
+- emit one bootstrap payload for scene/runtime consumers
+- include enough metadata for Player System and renderer initialization
+
+## Out of Scope
+
+- full world-authority simulation ownership
+- cooperative presence or party membership
+- long-term save-state persistence
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- downstream consumers include scene/runtime, renderer, and Player System

--- a/docs/tdrs/tdr-0003-authoritative-character-state-first-slice.md
+++ b/docs/tdrs/tdr-0003-authoritative-character-state-first-slice.md
@@ -1,0 +1,28 @@
+# TDR-0003: Authoritative character state and resume first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first slice of durable character state, inventory/equipment truth,
+and resume-safe restoration.
+
+## First Slice
+
+- persist a canonical character-state aggregate
+- persist inventory and equipment truth separate from local runtime stores
+- restore the current canonical state on resume or world re-entry
+- publish a runtime-hydration shape for downstream consumers
+
+## Out of Scope
+
+- final economy balancing
+- advanced crafting authority
+- multiplayer state synchronization
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- likely supporting schema work is needed in `entity-manager`

--- a/docs/tdrs/tdr-0004-game-capabilities-and-unlocks-first-slice.md
+++ b/docs/tdrs/tdr-0004-game-capabilities-and-unlocks-first-slice.md
@@ -1,0 +1,28 @@
+# TDR-0004: Game capabilities and unlocks first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first character-scoped capability answer for stage unlocks,
+institution readiness, and gated gameplay surfaces.
+
+## First Slice
+
+- answer what the active character may access now
+- express stage unlocks separately from rollout flags
+- express institution and authority readiness checks
+- provide one stable capability surface for Player System and UI preflight
+
+## Out of Scope
+
+- long-term entitlement billing models
+- admin capability-rule management
+- all late-game divine gating
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- this slice should stay distinct from existing account/profile capability flows

--- a/docs/tdrs/tdr-0005-party-presence-first-slice.md
+++ b/docs/tdrs/tdr-0005-party-presence-first-slice.md
@@ -1,0 +1,28 @@
+# TDR-0005: Party presence and friendly-tracking first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first slice of party truth, allied presence, and friendly-tracking
+state required by Party/System runtime surfaces.
+
+## First Slice
+
+- own party membership truth for the active character
+- publish basic allied presence and separation state
+- publish friendly-tracking summaries needed by combat-safe overlays
+- expose shared-objective identifiers for downstream consumers
+
+## Out of Scope
+
+- full social graph/friends platform
+- raid-scale coordination systems
+- guild authority ownership
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- runtime/UI consumers should treat this as upstream truth, not derive it locally

--- a/docs/tdrs/tdr-0006-external-authority-services-first-slice.md
+++ b/docs/tdrs/tdr-0006-external-authority-services-first-slice.md
@@ -1,0 +1,30 @@
+# TDR-0006: External authority services first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first service slice for guild, institution, and commerce authorities
+that remain external to the Player System.
+
+## First Slice
+
+- keep guild quest truth external and synchronizable
+- expose institution readiness/admission checks for schools, barracks,
+  academies, and apprenticeships
+- expose a first commerce/shop authority surface
+- provide stable authority-hand-off points for Player System orchestration
+
+## Out of Scope
+
+- full economy simulation
+- all late-stage divine influence systems
+- replacing Player System guidance behavior
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- existing guild/training issues should be reused where they already cover part
+  of this slice

--- a/docs/tdrs/tdr-0007-identity-card-projection-first-slice.md
+++ b/docs/tdrs/tdr-0007-identity-card-projection-first-slice.md
@@ -1,0 +1,28 @@
+# TDR-0007: Identity Card projection first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first runtime-facing projection slice for player and world-object
+Identity Card surfaces.
+
+## First Slice
+
+- publish one stable identity-card projection for the active player
+- publish bounded target projections for valid runtime targets
+- define disclosure rules for self, ally, and hostile/unknown targets
+- provide a projection surface consumable by Player System and runtime overlays
+
+## Out of Scope
+
+- full combat analytics
+- raw world-truth storage ownership
+- late-game social ranking displays
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- supporting schema and object-shape work is likely in `entity-manager`

--- a/docs/tdrs/tdr-0008-observed-event-pipeline-first-slice.md
+++ b/docs/tdrs/tdr-0008-observed-event-pipeline-first-slice.md
@@ -1,0 +1,30 @@
+# TDR-0008: Observed-event projection pipeline first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first service slice for observed-event ingestion, projected Event Log
+reads, achievements, and gossip-facing summaries.
+
+## First Slice
+
+- ingest observed gameplay events in an append-friendly shape
+- normalize and compact events in storage-backed processing
+- project curated player-facing Event Log and Achievement read models
+- emit player-safe gossip-relevant summaries derived from the same canonical
+  observed-event basis
+
+## Out of Scope
+
+- full real-time streaming guarantees
+- hidden server-only truth disclosure
+- replacing generic analytics ingestion
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- existing event-log, achievement, and gossip feature coverage should be reused
+  and extended where possible

--- a/docs/tdrs/tdr-0009-ai-authority-bridge-first-slice.md
+++ b/docs/tdrs/tdr-0009-ai-authority-bridge-first-slice.md
@@ -1,0 +1,29 @@
+# TDR-0009: AI authority bridge first implementation slice
+
+## Status
+
+Proposed
+
+## Goal
+
+Define the first bounded bridge from AI/chatbot outputs into NPC dialogue,
+NPC-action suggestions, and GM-style world mediation requests.
+
+## First Slice
+
+- accept bounded AI outputs from approved gameplay AI surfaces
+- classify outputs as advisory, deterministic-checkable, or operator-gated
+- translate approved outputs into stable runtime-facing authority requests
+- emit audit-friendly mediation results for downstream consumers
+
+## Out of Scope
+
+- free-form AI control over world-authoritative state
+- full autonomous NPC simulation ownership
+- replacing gameplay authority validation with generic chatbot logic
+
+## Delivery Notes
+
+- first implementation home should be `plasius-ltd-site`
+- supporting contract work is likely in `ai-game`
+- runtime/world authorities remain the final owner of authoritative mutations


### PR DESCRIPTION
Preserves local workspace changes or branch commits found during the worktree/branch orphan sweep.

Branch: `codex/preserve-road-map-feature-f358-road-map-baseline-governa-20260518`
Source repository: `Plasius-LTD/road-map`

Validation: not run in this sweep; this PR is draft and intended to prevent local work from being orphaned.
Generated/cache artifacts were intentionally excluded where the branch was created by the sweep.