### PR TITLE
docs: define profile/account timeout budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,6 @@ All notable changes to this repository are tracked here.
 - Added profile/account security control ownership and review cadence mapping
   (`docs/security/profile-account-security-control-ownership-and-review-cadence.md`)
   for Story `#177`.
+- Added explicit timeout/deadline budgets and propagation expectations for
+  profile/account reliability workstreams (`docs/security/profile-account-timeout-deadline-budgets.md`)
+  for Story `#231` in NFR Feature `#171`.

--- a/NFR.md
+++ b/NFR.md
@@ -17,6 +17,9 @@ This document records non-functional expectations for the planning repository.
   iterations.
 - Changes should preserve existing template compatibility unless explicitly
   versioned.
+- Timeout and deadline budgets for profile/account reliability controls are defined in
+  [`docs/security/profile-account-timeout-deadline-budgets.md`](./docs/security/profile-account-timeout-deadline-budgets.md),
+  including propagation and fallback behavior.
 
 ## 4. Accessibility and Comprehensibility
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Cross-repository planning and delivery tracking for Plasius packages.
 - Profile/account security control mapping: [OWASP Top 10 + ASVS profile/account matrix](./docs/security/owasp-asvs-profile-account-controls.md)
 - Profile/account threat model and data-flow diagrams: [`docs/security/profile-account-threat-model.md`](./docs/security/profile-account-threat-model.md)
 - Profile/account security ownership and review cadence: [`docs/security/profile-account-security-control-ownership-and-review-cadence.md`](./docs/security/profile-account-security-control-ownership-and-review-cadence.md)
+- Profile/account timeout and deadline budgets for reliability workstreams: [`docs/security/profile-account-timeout-deadline-budgets.md`](./docs/security/profile-account-timeout-deadline-budgets.md)
 
 ## Governance and contribution docs
 

--- a/docs/security/profile-account-timeout-deadline-budgets.md
+++ b/docs/security/profile-account-timeout-deadline-budgets.md
@@ -40,8 +40,12 @@ It is the source of truth for Story [`#183`](https://github.com/Plasius-LTD/road
 
 ## Call-chain composition rules
 
-1. No request should allocate more than `3000ms` at the start without explicit
-   exception and ticketed approval.
+1. Standard interactive request paths must not allocate more than `3000ms` at
+   the start. The OAuth callback, upload, and background reconciliation classes
+   in the endpoint table are pre-approved high-latency classes and may use their
+   listed `5000ms`/`6000ms` hard timeouts when the class is recorded in telemetry
+   and the fallback/error contract is implemented. Any other request above
+   `3000ms` still requires explicit exception and ticketed approval.
 2. Inner dependency budgets must be <= half of parent hard timeout unless the call is
    classified as high-latency external dependency.
 3. If a child budget exceeds the parent remaining budget, the child must use the parent

--- a/docs/security/profile-account-timeout-deadline-budgets.md
+++ b/docs/security/profile-account-timeout-deadline-budgets.md
@@ -1,0 +1,65 @@
+# Profile/account timeout and deadline budgets
+
+## Purpose
+
+This document defines explicit timeout and deadline budgets for profile/account workflows
+before implementation in `plasius-ltd-site` and supporting services.
+It is the source of truth for Story [`#183`](https://github.com/Plasius-LTD/road-map/issues/183).
+
+## Budget principles
+
+- Every outbound call in a request chain must have a bounded timeout.
+- Budgets are budgeted by class, then scaled by call position in a chain.
+- Deadline propagation is mandatory: inner calls use the remaining request budget.
+- Failures must return bounded `timeout`/`deadline` errors; do not extend retries through
+  request-lifetime expiry.
+- Soft budgets indicate pre-alert thresholds for telemetry; hard budgets are cancellation points.
+
+## Endpoint class budgets (profile/account surface)
+
+| Endpoint class | Representative operations | Soft budget | Hard timeout | Error contract / fallback |
+| --- | --- | --- | --- | --- |
+| Interactive read | `GET /profile`, session profile bootstrap, settings page shell load | `800ms` | `1500ms` | Render partial fallback + clear loading state; show retry affordance |
+| Interactive update | `PATCH /profile`, linked identity primary-switch mutation, field save | `1200ms` | `2500ms` | Preserve user input, show controlled retry state, avoid duplicate submit |
+| Security-sensitive mutation | Token/session revoke, passwordless step-up confirmation callbacks | `1500ms` | `3000ms` | Keep session state machine coherent, show secure fallback state |
+| OAuth callback | Identity provider callback exchange and verification | `2500ms` | `5000ms` | Continue callback state machine and surface verification failure state |
+| Uploads | Avatar upload initialization, blob stage/commit, content validation | `3000ms` | `6000ms` | Retry safe checkpoint, resumable upload messaging |
+| Background reconciliation | Deletion queue worker, profile retention jobs, policy sweep | `2000ms` | `5000ms` | Fail item fast, emit queue retry with bounded attempts |
+
+## Dependency budgets by client type
+
+| Dependency type | Soft budget | Hard timeout | Notes |
+| --- | --- | --- | --- |
+| Cosmos/SQL data read | `350ms` | `800ms` | Prefer projected reads and strict query bounds |
+| Cosmos/SQL data write | `500ms` | `1200ms` | Keep write batches bounded; fail fast on contention |
+| Internal service call (trusted boundary) | `250ms` | `900ms` | Short TTLs required; preserve downstream budget metadata |
+| Identity provider | `1200ms` | `2500ms` | No recursive token exchange retries; enforce provider timeout policy |
+| Blob/listing and download pre-signed token fetch | `700ms` | `1700ms` | Validate MIME and size before full stream continuation |
+| Notification/email dispatch | `800ms` | `2000ms` | Queue event on timeout for reliable retry in async worker |
+| Blob upload complete path | `1200ms` | `2500ms` | Keep multipart completion bounded; reissue idempotent completion token |
+
+## Call-chain composition rules
+
+1. No request should allocate more than `3000ms` at the start without explicit
+   exception and ticketed approval.
+2. Inner dependency budgets must be <= half of parent hard timeout unless the call is
+   classified as high-latency external dependency.
+3. If a child budget exceeds the parent remaining budget, the child must use the parent
+   remaining budget and a short per-attempt cap.
+4. Timeout exceptions are only permitted for audited, queue-backed fallback paths.
+
+## Deadline propagation pattern
+
+- All service boundaries should use request-scoped cancellation primitives (for example
+  `AbortController`, `CancellationToken`, `Context`, depending on runtime).
+- Middleware should translate client request deadlines into dependency budgets.
+- Deadline information should be emitted via trace metadata for correlation and audit.
+- On timeout, request paths should avoid side effects beyond the failed call boundary.
+
+## Test expectations
+
+- Add timeout-budget unit/integration tests for representative endpoint classes.
+- Add synthetic tests that validate cancellation propagation through chain boundaries.
+- Add telemetry assertions on budget exceeded events and verify alerting for repeated breaches.
+- Publish budget breach and fallback-path test evidence before closing Story `#183` and
+  related downstream task tickets.


### PR DESCRIPTION
## Summary
- Rebased the timeout/deadline budget guidance branch onto the latest `main`.
- Added profile/account timeout and deadline budget policy for Story #183.
- Added explicit endpoint and dependency budget tables with cancellation and fallback expectations.
- Updated README, NFR, and changelog references.

## Requirement / purpose
- Documents timeout and deadline budgets for profile/account flows.
- Closes #231.

## Key changes
- Adds `docs/security/profile-account-timeout-deadline-budgets.md`.
- Updates `NFR.md` and `README.md` to reference the timeout/deadline guidance.
- Adds an Unreleased changelog entry.

## Tests run
- `git diff --check main...HEAD`
- No package/build/test command was found in this docs-only checkout (`package.json`, Makefile, language project files, and `.github/workflows` were absent).

## Risks or follow-up work
- Documentation-only change; no runtime risk identified.
- CI status should be checked after GitHub refreshes the rebased branch.