### PR TITLE
docs: add profile/account compliance runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this repository are tracked here.
 - Added explicit timeout/deadline budgets and propagation expectations for
   profile/account reliability workstreams (`docs/security/profile-account-timeout-deadline-budgets.md`)
   for Story `#231` in NFR Feature `#171`.
+- Added a compliance runbook and recurring control-review checklist for profile/account
+  evidence under Story `#182` (`docs/security/profile-account-compliance-runbook.md`).
 - Added a compliance control mapping for profile/account flows covering GDPR / UK
   GDPR / CCPA / SOC 2 touchpoints (`docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md`)
   for Story `#182` in Feature `#170`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Cross-repository planning and delivery tracking for Plasius packages.
 - Profile/account security ownership and review cadence: [`docs/security/profile-account-security-control-ownership-and-review-cadence.md`](./docs/security/profile-account-security-control-ownership-and-review-cadence.md)
 - Profile/account timeout and deadline budgets for reliability workstreams: [`docs/security/profile-account-timeout-deadline-budgets.md`](./docs/security/profile-account-timeout-deadline-budgets.md)
 - Profile/account legal/control mapping for GDPR/UK GDPR/CCPA/SOC 2: [`docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md`](./docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md)
+- Profile/account compliance runbook and recurring control-review checklist: [`docs/security/profile-account-compliance-runbook.md`](./docs/security/profile-account-compliance-runbook.md)
 
 ## Governance and contribution docs
 

--- a/docs/security/profile-account-compliance-runbook.md
+++ b/docs/security/profile-account-compliance-runbook.md
@@ -1,0 +1,76 @@
+# Profile/account compliance runbook and recurring control-review checklist
+
+## Scope
+
+This runbook captures the operational and governance controls for profile/account
+flows under Feature `#170` and Story `#182` (GDPR/CCPA/SOC2-aligned operations).
+
+It complements:
+
+- `docs/security/profile-account-security-control-ownership-and-review-cadence.md`
+- `docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md`
+- `docs/security/owasp-asvs-profile-account-controls.md`
+- `docs/security/profile-account-threat-model.md`
+
+## Pre-release compliance checks
+
+Before any profile/account release:
+
+1. Confirm the task-level evidence is updated for all merged changes in the current cycle.
+2. Verify DSAR/export/delete flows remain in sync with retention policy changes from Task `#227`.
+3. Confirm role and privilege boundaries for profile mutations and linked-identity operations are still covered by tests/PR evidence.
+4. Confirm audit trail retention and redaction expectations are unchanged by the release.
+5. Record a short compliance review note in the issue/ PR evidence trail.
+
+## Recurring review schedule
+
+| Cadence | Required actions | Owner | Evidence |
+| --- | --- | --- | --- |
+| Weekly | Review new profile/account PRs for data-boundary, retention, and access-control changes. | Profile/account feature owner + Security | Project row comments + PR evidence |
+| Bi-weekly | Validate open compliance gaps for DSAR workflow quality and test coverage. | Privacy owner | Story `#182` checklist delta and docs snapshots |
+| Monthly | Reconcile legal/control mapping artifact against implemented controls. | Security lead + SRE lead | Updated mapping row review + risk register entry |
+| Quarterly | Conduct tabletop review for deletion, retention, and identity-control incidents. | Product, Security, SRE leadership | Incident postmortems + action tracker |
+
+## Core operational runbooks
+
+### 1. Data-subject request workflow
+
+- Acknowledge request and confirm identity using existing profile/account identity controls.
+- Resolve request type (access / delete / export) and route to the privacy coordinator.
+- Validate all relevant datastore entries before data export or deletion.
+- Log request lifecycle with timestamps and completion confirmation.
+
+### 2. Deletion and retention validation
+
+- Confirm retention policy in the current release branch matches Task `#227` evidence.
+- Execute retention/deletion dry-runs in non-production where feasible.
+- Capture whether soft-delete and recovery windows are still enforced.
+- Document any accidental retention misses and escalate through issue tracking immediately.
+
+### 3. Identity and auth integrity monitoring
+
+- Monitor linked identity primary-switch and ownership transitions for unreviewed anomalies.
+- Validate alerts for suspicious re-link or owner-change behavior.
+- Ensure logout/session invalidation behavior remains safe when retrying or under partial outage.
+
+### 4. Control evidence maintenance
+
+- Update `docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md` when controls change.
+- Confirm all mapped controls point to concrete evidence (tests, issues, threat model sections, or operations docs).
+- Remove stale controls and add new mappings for introduced feature flags, endpoints, or data paths.
+
+## Checklist template
+
+When completing each review cycle, collect:
+
+- [ ] Scope and change summary.
+- [ ] Last review date and owner.
+- [ ] Controls reviewed and evidence links added/updated.
+- [ ] Open gaps with owner/target close date.
+- [ ] Security/privacy sign-off for continued rollout.
+
+## Escalation
+
+- If high-risk control regressions are found, raise a linked blocker issue in the
+  `Plasius-LTD-site` project immediately and pause profile/account rollout pending
+  remediation.

--- a/docs/security/profile-account-security-control-ownership-and-review-cadence.md
+++ b/docs/security/profile-account-security-control-ownership-and-review-cadence.md
@@ -36,6 +36,8 @@ All security controls below apply to the profile/account auth, profile, identity
 - If any high-risk gap is identified, it is logged as a linked blocker issue in the
   `Plasius-LTD-site` project and moved to the top of the project queue.
 - Ownership changes require PR evidence and a project comment referencing updated control matrix entries.
+- Recurring control-review execution references are maintained in
+  [`docs/security/profile-account-compliance-runbook.md`](./profile-account-compliance-runbook.md).
 
 ## NFR alignment
 


### PR DESCRIPTION
## Summary

- Added a profile/account compliance runbook and recurring control-review checklist in:
  `docs/security/profile-account-compliance-runbook.md`.
- Linked the runbook from `README.md` and changelog.
- Connected the runbook into existing security ownership references for recurring review traceability.

## Validation
- Repository is docs-only; no code paths or automated test suites were executed for this change.
- Manual documentation review confirms task #229 acceptance coverage against Story #182 scope.
