### PR TITLE
docs: add NFR compliance criteria mapping for profile/account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this repository are tracked here.
   for Story `#231` in NFR Feature `#171`.
 - Added a compliance runbook and recurring control-review checklist for profile/account
   evidence under Story `#182` (`docs/security/profile-account-compliance-runbook.md`).
+- Added an explicit `NFR-Compliance` criteria matrix for Story `#182` mapping
+  implemented profile/account controls to documented compliance criteria
+  (`docs/security/profile-account-compliance-criteria-matrix.md`).
 - Added a compliance control mapping for profile/account flows covering GDPR / UK
   GDPR / CCPA / SOC 2 touchpoints (`docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md`)
   for Story `#182` in Feature `#170`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Cross-repository planning and delivery tracking for Plasius packages.
 - Profile/account timeout and deadline budgets for reliability workstreams: [`docs/security/profile-account-timeout-deadline-budgets.md`](./docs/security/profile-account-timeout-deadline-budgets.md)
 - Profile/account legal/control mapping for GDPR/UK GDPR/CCPA/SOC 2: [`docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md`](./docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md)
 - Profile/account compliance runbook and recurring control-review checklist: [`docs/security/profile-account-compliance-runbook.md`](./docs/security/profile-account-compliance-runbook.md)
+- Profile/account explicit compliance criteria matrix (NFR-Compliance evidence): [`docs/security/profile-account-compliance-criteria-matrix.md`](./docs/security/profile-account-compliance-criteria-matrix.md)
 
 ## Governance and contribution docs
 

--- a/docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md
+++ b/docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md
@@ -56,3 +56,5 @@ Feature `#170`.
 - [ ] Add a compliance review timestamp in the story evidence thread after each milestone.
 - [ ] Publish a concise legal-control matrix export for `NFR-Compliance` review.
 - [ ] Record remaining gaps and owners for unresolved evidence against each mapping row.
+- [ ] Keep the explicit criteria matrix in
+  [`docs/security/profile-account-compliance-criteria-matrix.md`](./profile-account-compliance-criteria-matrix.md) aligned whenever controls evolve.

--- a/docs/security/profile-account-compliance-criteria-matrix.md
+++ b/docs/security/profile-account-compliance-criteria-matrix.md
@@ -1,0 +1,26 @@
+# Profile/account explicit compliance criteria matrix
+
+## Scope
+
+This matrix maps implemented profile/account controls to explicit legal and control criteria for
+Feature `#170` / Story `#182` and supports NFR `NFR-Compliance`.
+
+## Implemented control evidence matrix
+
+| Compliance criterion | Implemented control | Evidence source | Validation note |
+| --- | --- | --- | --- |
+| Data minimisation and purpose limitation | Profile/account schema scope and ownership fields are constrained to product-required data | `docs/security/owasp-asvs-profile-account-controls.md` + `docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md` | Validate new data fields through PR review and schema tests before merge |
+| Access and deletion rights readiness | DSAR/delete workflow ownership and retention behavior coverage in progress and evidence in Story `#182` (`#227`) | `#227` implementation; Task `#228` legal/control mapping | Verify deletion/retention controls against recurring runbook checkpoints |
+| Retention and archival controls | Retention and soft-delete behavior documented and planned in control mapping/runbook | `docs/security/profile-account-compliance-runbook.md` + `docs/security/profile-account-compliance-control-mapping-gdpr-ccpa-soc2.md` | Confirm runtime config and scheduled cleanup behavior when retention-related code changes land |
+| Security ownership and review cadence | Role and periodic review responsibilities established | `docs/security/profile-account-security-control-ownership-and-review-cadence.md` | Review cadence is actively tracked in project/issue evidence threads |
+| Recurring control-review and audit | Recurring checklist and evidence capture added | `docs/security/profile-account-compliance-runbook.md` | Execute checklist at each recurring cycle and close open gaps in story-level evidence |
+
+## Verification checkpoints
+
+- Link each implemented control update back to this matrix row.
+- Keep evidence links current when control behavior or data paths change.
+- Escalate any criterion with missing evidence as a blocker issue in the `Plasius-LTD-site` project.
+
+## Current status
+
+- This matrix is complete for Story `#182` documentation controls and is awaiting final Story-level sign-off after all planned compliance controls are implemented in-product paths.


### PR DESCRIPTION
## Summary

- Added an explicit `NFR-Compliance` criteria matrix for Story `#182` in:
  `docs/security/profile-account-compliance-criteria-matrix.md`.
- Linked this matrix from README and aligned it with existing compliance runbook/control-mapping docs.
- Recorded the update in `CHANGELOG.md`.

## Validation
- Repository is docs-only for this change; no code-level test pipeline exists.
- Manual documentation review completed with traceability checks against Story `#182` tasks.
