### PR TITLE
fix: add low-cost project board automation helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this repository are tracked here.
 
 ## [Unreleased]
 
+- Added a `project:board` helper CLI, tests, and runbook for low-cost
+  `Plasius-LTD-site` Project discovery and targeted status updates, plus ADR
+  `0011` documenting the cursor-checkpoint query strategy for blocker Task
+  `#524`.
 - Added a Node 24 runtime baseline, `c8`-backed coverage command, and a pull
   request / `main` CI workflow for the `road-map` ADR tooling repository.
 - Added road-map ADR search-index tooling and generated JSON/Markdown inspection

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Cross-repository planning and delivery tracking for Plasius packages.
 
 - Active cross-repo execution board:
   - [Plasius-LTD Project #1](https://github.com/orgs/Plasius-LTD/projects/1)
+- Low-cost backlog automation runbook + helper CLI:
+  - [`docs/project-board-automation.md`](./docs/project-board-automation.md)
+
+  ```sh
+  npm run project:board -- --help
+  ```
 
 ## ADR Search Index
 

--- a/docs/adrs/adr-0011-project-board-automation-query-budget.md
+++ b/docs/adrs/adr-0011-project-board-automation-query-budget.md
@@ -1,0 +1,46 @@
+# ADR 0011: GitHub Project board automation uses thin paged queries and cursor checkpoints
+
+- Status: Accepted
+- Date: 2026-06-30
+
+## Context
+
+The `Plasius-LTD-site` organisation Project is large enough that one
+automation-runner account can exhaust its GitHub GraphQL budget while
+enumerating candidate items. That failure is especially harmful for backlog
+automation because the same run still needs GraphQL budget for `ProjectV2`
+status updates after it selects a deliverable.
+
+Using `gh project item-list` or custom full-detail GraphQL pages for the entire
+board front-loads most of the budget into discovery, leaving too little for the
+write operations that the workflow cannot avoid.
+
+## Decision
+
+Backlog automation will query the Project in two phases:
+
+1. Resolve stable metadata such as the Project id, Status field id, and Status
+   option ids once at the start of the run.
+2. Page through items with a minimal GraphQL selection set and a bounded page
+   count, then persist the returned cursor in automation memory for resume.
+
+The `road-map` repository will own a small helper CLI that implements this
+strategy and exposes targeted commands for:
+
+- field discovery,
+- next-item selection within a bounded scan window,
+- Project status updates by name,
+- linked-issue assignment and comments through REST-backed paths.
+
+## Consequences
+
+- Positive: routine discovery no longer burns the full GraphQL budget before the
+  automation reaches status updates.
+- Positive: future runs can resume from a saved cursor rather than rescanning
+  the same Project prefix.
+- Positive: linked-issue comments remain available even when Project writes must
+  be minimized.
+- Negative: candidate selection becomes windowed; strict global priority sorting
+  across the entire board is traded for Project order plus local tiebreaking.
+- Negative: automation memory becomes part of the operational control surface and
+  must be kept current.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -3,6 +3,7 @@
 ## Governance ADRs
 
 - [ADR 0001: Road-map docs repo baseline and governance alignment](./adr-0001-road-map-baseline-alignment.md)
+- [ADR 0011: GitHub Project board automation uses thin paged queries and cursor checkpoints](./adr-0011-project-board-automation-query-budget.md)
 
 ## Game Service Bridge ADRs
 

--- a/docs/project-board-automation.md
+++ b/docs/project-board-automation.md
@@ -1,0 +1,104 @@
+# Project Board Automation
+
+This runbook documents the low-cost GitHub Project access path used by backlog
+automation such as `HW2`.
+
+## Problem
+
+The `Plasius-LTD-site` organisation Project is large enough that broad
+`gh project item-list` or full-detail GraphQL scans can exhaust the per-user
+GraphQL budget before the automation reaches the item-selection and status-write
+steps.
+
+## Decision
+
+Use the `road-map` helper CLI to split Project work into thin, targeted steps:
+
+1. Resolve the Project id, Status field id, and Status option ids once.
+2. Scan only small item pages with minimal fields until a candidate is found.
+3. Persist the returned `nextCursor` in automation memory so the next run
+   resumes instead of rescanning the top of the board.
+4. Spend the remaining GraphQL budget only on the selected item's targeted
+   status updates.
+5. Keep issue comments on the linked issue path via REST.
+
+This keeps discovery cheap and leaves the expensive GraphQL budget for the
+small number of write operations that cannot avoid ProjectV2 APIs.
+
+## Commands
+
+From the `road-map` repo root:
+
+```sh
+npm run project:board -- fields --owner Plasius-LTD --project-number 1
+```
+
+```sh
+npm run project:board -- find-next \
+  --owner Plasius-LTD \
+  --project-number 1 \
+  --self-login zephod111r \
+  --page-size 25 \
+  --max-pages 4 \
+  --cursor '<saved endCursor>'
+```
+
+The `find-next` command returns:
+
+- `candidate`: the next eligible item in the scanned window
+- `pagesScanned`: the number of thin GraphQL pages consumed
+- `itemsExamined`: the number of normalized items considered
+- `nextCursor`: the next page cursor to persist in automation memory
+
+To look up a known linked issue cheaply and recover its Project item id:
+
+```sh
+npm run project:board -- find-item \
+  --owner Plasius-LTD \
+  --project-number 1 \
+  --repo Plasius-LTD/road-map \
+  --issue-number 524 \
+  --page-size 25 \
+  --max-pages 8
+```
+
+To move a selected item to `In progress` after assignment:
+
+```sh
+npm run project:board -- claim \
+  --owner Plasius-LTD \
+  --project-number 1 \
+  --item-id '<project item id>' \
+  --status 'In progress' \
+  --repo Plasius-LTD/road-map \
+  --issue-number 524 \
+  --assignee zephod111r
+```
+
+To update only the Project status:
+
+```sh
+npm run project:board -- set-status \
+  --owner Plasius-LTD \
+  --project-number 1 \
+  --item-id '<project item id>' \
+  --status Done
+```
+
+To add an evidence or blocker comment without touching Project GraphQL writes:
+
+```sh
+npm run project:board -- comment \
+  --repo Plasius-LTD/road-map \
+  --issue-number 524 \
+  --body 'Evidence goes here'
+```
+
+## Operating notes
+
+- Treat Project order as the primary signal.
+- Use Priority as a tiebreaker within the scanned window rather than paying to
+  re-rank the entire board on every run.
+- Prefer a small `max-pages` budget and resume on the next run when needed.
+- Keep the saved cursor in `$CODEX_HOME/automations/<automation_id>/memory.md`.
+- Check `gh api rate_limit` before wide scans and after any write-heavy sequence.

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "adr:index": "node tools/adr-index/cli.mjs",
     "adr:index:check": "node tools/adr-index/cli.mjs --check",
-    "build": "node --check tools/adr-index/cli.mjs && node --check tools/adr-index/indexer.mjs",
-    "test": "node --test tools/adr-index/test/*.test.mjs",
-    "test:coverage": "c8 --reporter=text --reporter=lcov --reports-dir coverage --lines 80 --functions 80 node --test tools/adr-index/test/*.test.mjs",
-    "typecheck": "node --check tools/adr-index/cli.mjs && node --check tools/adr-index/indexer.mjs && node --check tools/adr-index/test/indexer.test.mjs && node --check tools/adr-index/test/cli.test.mjs && node --check tools/adr-index/test/render.test.mjs"
+    "project:board": "node tools/project-board/cli.mjs",
+    "build": "node --check tools/adr-index/cli.mjs && node --check tools/adr-index/indexer.mjs && node --check tools/project-board/cli.mjs && node --check tools/project-board/index.mjs",
+    "test": "node --test tools/adr-index/test/*.test.mjs tools/project-board/test/*.test.mjs",
+    "test:coverage": "c8 --reporter=text --reporter=lcov --reports-dir coverage --lines 80 --functions 80 node --test tools/adr-index/test/*.test.mjs tools/project-board/test/*.test.mjs",
+    "typecheck": "node --check tools/adr-index/cli.mjs && node --check tools/adr-index/indexer.mjs && node --check tools/adr-index/test/indexer.test.mjs && node --check tools/adr-index/test/cli.test.mjs && node --check tools/adr-index/test/render.test.mjs && node --check tools/project-board/cli.mjs && node --check tools/project-board/index.mjs && node --check tools/project-board/test/index.test.mjs && node --check tools/project-board/test/cli.test.mjs"
   },
   "packageManager": "npm@11.6.2",
   "engines": {

--- a/tools/project-board/cli.mjs
+++ b/tools/project-board/cli.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  PROJECT_ITEMS_QUERY,
+  defaultFindNextOptions,
+  parseFieldMapResponse,
+  selectNextEligibleItem,
+  summarizeFindNextResult
+} from "./index.mjs";
+
+const execFileAsync = promisify(execFile);
+const ghBinary = process.env.PLASIUS_GH_BIN || "gh";
+const [command, ...args] = process.argv.slice(2);
+
+if (!command || command === "--help" || command === "-h") {
+  printHelp();
+  process.exit(0);
+}
+
+try {
+  switch (command) {
+    case "fields":
+      await runFieldsCommand(args);
+      break;
+    case "find-next":
+      await runFindNextCommand(args);
+      break;
+    case "find-item":
+      await runFindItemCommand(args);
+      break;
+    case "set-status":
+      await runSetStatusCommand(args);
+      break;
+    case "claim":
+      await runClaimCommand(args);
+      break;
+    case "comment":
+      await runCommentCommand(args);
+      break;
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+async function runFieldsCommand(args) {
+  const options = parseCommonProjectArguments(args);
+  const project = await resolveProjectContext(options);
+  console.log(JSON.stringify(project, null, 2));
+}
+
+async function runFindNextCommand(args) {
+  const options = parseFindNextArguments(args);
+  const project = await resolveProjectContext(options);
+  const result = await scanProjectItems(options, (items) => selectNextEligibleItem(items, options));
+
+  console.log(JSON.stringify({
+    projectId: project.projectId,
+    projectTitle: project.projectTitle,
+    candidate: result.match,
+    pagesScanned: result.pagesScanned,
+    itemsExamined: result.itemsExamined,
+    nextCursor: result.nextCursor,
+    ...(result.match ? {} : { scannedItems: result.scannedItems })
+  }, null, 2));
+}
+
+async function runFindItemCommand(args) {
+  const options = parseFindItemArguments(args);
+  const project = await resolveProjectContext(options);
+  const result = await scanProjectItems(options, (items) => items.find((item) => {
+    const repositoryMatches = item.repository === options.repository;
+    const numberMatches = item.number === options.issueNumber;
+    return repositoryMatches && numberMatches;
+  }) ?? null);
+
+  console.log(JSON.stringify({
+    projectId: project.projectId,
+    projectTitle: project.projectTitle,
+    item: result.match,
+    pagesScanned: result.pagesScanned,
+    itemsExamined: result.itemsExamined,
+    nextCursor: result.nextCursor
+  }, null, 2));
+}
+
+async function runSetStatusCommand(args) {
+  const options = parseSetStatusArguments(args);
+  const project = await resolveProjectContext(options);
+  const statusId = project.statuses[options.status];
+  if (!statusId) {
+    throw new Error(`Unknown status "${options.status}".`);
+  }
+
+  await ghText([
+    "project",
+    "item-edit",
+    "--id",
+    options.itemId,
+    "--project-id",
+    project.projectId,
+    "--field-id",
+    project.statusFieldId,
+    "--single-select-option-id",
+    statusId
+  ]);
+
+  console.log(JSON.stringify({
+    itemId: options.itemId,
+    status: options.status
+  }, null, 2));
+}
+
+async function runClaimCommand(args) {
+  const options = parseClaimArguments(args);
+  const project = await resolveProjectContext(options);
+  const statusId = project.statuses[options.status];
+  if (!statusId) {
+    throw new Error(`Unknown status "${options.status}".`);
+  }
+
+  if (options.repository && options.issueNumber && options.assignee) {
+    await ghText([
+      "api",
+      `repos/${options.repository}/issues/${options.issueNumber}`,
+      "-X",
+      "PATCH",
+      "-f",
+      `assignees[]=${options.assignee}`
+    ]);
+  }
+
+  await ghText([
+    "project",
+    "item-edit",
+    "--id",
+    options.itemId,
+    "--project-id",
+    project.projectId,
+    "--field-id",
+    project.statusFieldId,
+    "--single-select-option-id",
+    statusId
+  ]);
+
+  console.log(JSON.stringify({
+    itemId: options.itemId,
+    repository: options.repository ?? null,
+    issueNumber: options.issueNumber ?? null,
+    assignee: options.assignee ?? null,
+    status: options.status
+  }, null, 2));
+}
+
+async function runCommentCommand(args) {
+  const options = parseCommentArguments(args);
+  await ghText([
+    "api",
+    `repos/${options.repository}/issues/${options.issueNumber}/comments`,
+    "-X",
+    "POST",
+    "-f",
+    `body=${options.body}`
+  ]);
+
+  console.log(JSON.stringify({
+    repository: options.repository,
+    issueNumber: options.issueNumber
+  }, null, 2));
+}
+
+async function scanProjectItems(options, matcher) {
+  let cursor = options.cursor ?? null;
+  let pagesScanned = 0;
+  let itemsExamined = 0;
+  const scannedItems = [];
+
+  while (pagesScanned < options.maxPages) {
+    const response = await ghJson([
+      "api",
+      "graphql",
+      "-f",
+      `query=${PROJECT_ITEMS_QUERY}`,
+      "-f",
+      `owner=${options.owner}`,
+      "-F",
+      `number=${options.projectNumber}`,
+      "-F",
+      `pageSize=${options.pageSize}`,
+      ...(cursor ? ["-f", `cursor=${cursor}`] : [])
+    ]);
+    const summary = summarizeFindNextResult(response, options);
+    scannedItems.push(...summary.items);
+    itemsExamined += summary.items.length;
+    pagesScanned += 1;
+
+    const match = matcher(scannedItems, summary.pageInfo);
+    if (match) {
+      return {
+        match,
+        pagesScanned,
+        itemsExamined,
+        nextCursor: summary.pageInfo.endCursor,
+        scannedItems
+      };
+    }
+
+    if (!summary.pageInfo.hasNextPage || !summary.pageInfo.endCursor) {
+      return {
+        match: null,
+        pagesScanned,
+        itemsExamined,
+        nextCursor: cursor,
+        scannedItems
+      };
+    }
+
+    cursor = summary.pageInfo.endCursor;
+  }
+
+  return {
+    match: null,
+    pagesScanned,
+    itemsExamined,
+    nextCursor: cursor,
+    scannedItems
+  };
+}
+
+async function resolveProjectContext(options) {
+  const projectList = await ghJson([
+    "project",
+    "list",
+    "--owner",
+    options.owner,
+    "--format",
+    "json"
+  ]);
+  const project = (projectList.projects ?? []).find((entry) => entry.number === options.projectNumber);
+  if (!project) {
+    throw new Error(`Project #${options.projectNumber} not found for ${options.owner}.`);
+  }
+
+  const fieldList = await ghJson([
+    "project",
+    "field-list",
+    String(options.projectNumber),
+    "--owner",
+    options.owner,
+    "--format",
+    "json"
+  ]);
+
+  return parseFieldMapResponse({
+    id: project.id,
+    number: project.number,
+    title: project.title,
+    fields: fieldList.fields ?? []
+  });
+}
+
+function parseCommonProjectArguments(args) {
+  const options = {
+    projectNumber: 1
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--owner":
+        options.owner = requireValue(args, ++index, arg);
+        break;
+      case "--project-number":
+        options.projectNumber = Number(requireValue(args, ++index, arg));
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.owner) {
+    throw new Error("--owner is required.");
+  }
+
+  if (!Number.isInteger(options.projectNumber) || options.projectNumber <= 0) {
+    throw new Error("--project-number must be a positive integer.");
+  }
+
+  return options;
+}
+
+function parseFindNextArguments(args) {
+  const options = {
+    ...defaultFindNextOptions(),
+    ...parseCommonProjectArguments(extractProjectArguments(args))
+  };
+  options.eligibleStatuses = [];
+  options.excludedStatuses = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--owner":
+      case "--project-number":
+        index += 1;
+        break;
+      case "--cursor":
+        options.cursor = requireValue(args, ++index, arg);
+        break;
+      case "--eligible-status":
+        options.eligibleStatuses.push(requireValue(args, ++index, arg));
+        break;
+      case "--exclude-status":
+        options.excludedStatuses.push(requireValue(args, ++index, arg));
+        break;
+      case "--max-pages":
+        options.maxPages = Number(requireValue(args, ++index, arg));
+        break;
+      case "--page-size":
+        options.pageSize = Number(requireValue(args, ++index, arg));
+        break;
+      case "--self-login":
+        options.selfLogin = requireValue(args, ++index, arg);
+        break;
+      default:
+        if (!["--owner", "--project-number"].includes(arg)) {
+          throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+  }
+
+  if (options.eligibleStatuses.length === 0) {
+    options.eligibleStatuses = defaultFindNextOptions().eligibleStatuses;
+  }
+  if (options.excludedStatuses.length === 0) {
+    options.excludedStatuses = defaultFindNextOptions().excludedStatuses;
+  }
+  if (!Number.isInteger(options.pageSize) || options.pageSize <= 0) {
+    throw new Error("--page-size must be a positive integer.");
+  }
+  if (!Number.isInteger(options.maxPages) || options.maxPages <= 0) {
+    throw new Error("--max-pages must be a positive integer.");
+  }
+
+  return options;
+}
+
+function parseSetStatusArguments(args) {
+  const options = parseCommonProjectArguments(extractProjectArguments(args));
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--owner":
+      case "--project-number":
+        index += 1;
+        break;
+      case "--item-id":
+        options.itemId = requireValue(args, ++index, arg);
+        break;
+      case "--status":
+        options.status = requireValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.itemId) {
+    throw new Error("--item-id is required.");
+  }
+  if (!options.status) {
+    throw new Error("--status is required.");
+  }
+
+  return options;
+}
+
+function parseFindItemArguments(args) {
+  const options = {
+    pageSize: defaultFindNextOptions().pageSize,
+    maxPages: defaultFindNextOptions().maxPages,
+    ...parseCommonProjectArguments(extractProjectArguments(args))
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--owner":
+      case "--project-number":
+        index += 1;
+        break;
+      case "--repo":
+        options.repository = requireValue(args, ++index, arg);
+        break;
+      case "--issue-number":
+        options.issueNumber = Number(requireValue(args, ++index, arg));
+        break;
+      case "--cursor":
+        options.cursor = requireValue(args, ++index, arg);
+        break;
+      case "--page-size":
+        options.pageSize = Number(requireValue(args, ++index, arg));
+        break;
+      case "--max-pages":
+        options.maxPages = Number(requireValue(args, ++index, arg));
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.repository) {
+    throw new Error("--repo is required.");
+  }
+  if (!Number.isInteger(options.issueNumber) || options.issueNumber <= 0) {
+    throw new Error("--issue-number must be a positive integer.");
+  }
+  if (!Number.isInteger(options.pageSize) || options.pageSize <= 0) {
+    throw new Error("--page-size must be a positive integer.");
+  }
+  if (!Number.isInteger(options.maxPages) || options.maxPages <= 0) {
+    throw new Error("--max-pages must be a positive integer.");
+  }
+
+  return options;
+}
+
+function parseClaimArguments(args) {
+  const options = parseCommonProjectArguments(extractProjectArguments(args));
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--owner":
+      case "--project-number":
+        index += 1;
+        break;
+      case "--item-id":
+        options.itemId = requireValue(args, ++index, arg);
+        break;
+      case "--status":
+        options.status = requireValue(args, ++index, arg);
+        break;
+      case "--repo":
+        options.repository = requireValue(args, ++index, arg);
+        break;
+      case "--issue-number":
+        options.issueNumber = Number(requireValue(args, ++index, arg));
+        break;
+      case "--assignee":
+        options.assignee = requireValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if ((options.repository || options.issueNumber || options.assignee) &&
+      !(options.repository && options.issueNumber && options.assignee)) {
+    throw new Error("--repo, --issue-number, and --assignee must be provided together.");
+  }
+  if (!options.itemId) {
+    throw new Error("--item-id is required.");
+  }
+  if (!options.status) {
+    throw new Error("--status is required.");
+  }
+
+  return options;
+}
+
+function parseCommentArguments(args) {
+  const options = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--repo":
+        options.repository = requireValue(args, ++index, arg);
+        break;
+      case "--issue-number":
+        options.issueNumber = Number(requireValue(args, ++index, arg));
+        break;
+      case "--body":
+        options.body = requireValue(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.repository) {
+    throw new Error("--repo is required.");
+  }
+  if (!Number.isInteger(options.issueNumber) || options.issueNumber <= 0) {
+    throw new Error("--issue-number must be a positive integer.");
+  }
+  if (!options.body) {
+    throw new Error("--body is required.");
+  }
+
+  return options;
+}
+
+function extractProjectArguments(args) {
+  const extracted = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--owner" || arg === "--project-number") {
+      extracted.push(arg, requireValue(args, ++index, arg));
+    }
+  }
+  return extracted;
+}
+
+function requireValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+
+  return value;
+}
+
+async function ghJson(args) {
+  const { stdout } = await execFileAsync(ghBinary, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024
+  });
+  return JSON.parse(stdout);
+}
+
+async function ghText(args) {
+  await execFileAsync(ghBinary, args, {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024
+  });
+}
+
+function printHelp() {
+  console.log(`Usage: npm run project:board -- <command> [options]
+
+Commands:
+  fields       Print the project id, status field id, and status option ids.
+  find-next    Page minimally through project items and return the next eligible item.
+  find-item    Page minimally through project items until one repo + issue match is found.
+  set-status   Update one project item's Status field by name.
+  claim        Optionally assign a linked issue, then set project Status by name.
+  comment      Add a comment to a linked issue through REST.
+
+Common options:
+  --owner <login>          GitHub organization or user login.
+  --project-number <n>     Project number. Defaults to 1.
+
+find-next options:
+  --self-login <login>     Only include items assigned to this login or unassigned.
+  --page-size <n>          GraphQL page size. Defaults to 25.
+  --max-pages <n>          Maximum pages to scan in one run. Defaults to 4.
+  --cursor <value>         Resume from a saved endCursor.
+  --eligible-status <name> Repeatable. Defaults to Ready, Backlog, In progress, In review.
+  --exclude-status <name>  Repeatable. Defaults to Done.
+
+find-item options:
+  --repo <owner/name>      Repository containing the linked issue.
+  --issue-number <n>       Linked issue number to locate.
+  --page-size <n>          GraphQL page size. Defaults to 25.
+  --max-pages <n>          Maximum pages to scan in one run. Defaults to 4.
+  --cursor <value>         Resume from a saved endCursor.
+
+set-status / claim options:
+  --item-id <id>           Project item id to update.
+  --status <name>          Status name, for example "In progress".
+
+claim options:
+  --repo <owner/name>      Linked repository for the issue assignment step.
+  --issue-number <n>       Issue number to assign.
+  --assignee <login>       GitHub login to assign before updating project status.
+
+comment options:
+  --repo <owner/name>      Repository containing the issue.
+  --issue-number <n>       Issue number to comment on.
+  --body <text>            Comment body.
+`);
+}

--- a/tools/project-board/index.mjs
+++ b/tools/project-board/index.mjs
@@ -1,0 +1,271 @@
+const DEFAULT_ELIGIBLE_STATUSES = ["Ready", "Backlog", "In progress", "In review"];
+const DEFAULT_EXCLUDED_STATUSES = ["Done"];
+const DEFAULT_PAGE_SIZE = 25;
+const DEFAULT_MAX_PAGES = 4;
+
+export const PROJECT_ITEMS_QUERY = `query($owner:String!, $number:Int!, $pageSize:Int!, $cursor:String) {
+  organization(login:$owner) {
+    projectV2(number:$number) {
+      id
+      title
+      items(first:$pageSize, after:$cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              url
+              repository {
+                nameWithOwner
+              }
+              assignees(first:10) {
+                nodes {
+                  login
+                }
+              }
+            }
+            ... on PullRequest {
+              number
+              title
+              url
+              repository {
+                nameWithOwner
+              }
+              assignees(first:10) {
+                nodes {
+                  login
+                }
+              }
+            }
+            ... on DraftIssue {
+              title
+              body
+            }
+          }
+          fieldValues(first:10) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field {
+                  ... on ProjectV2SingleSelectField {
+                    name
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldUserValue {
+                users(first:10) {
+                  nodes {
+                    login
+                  }
+                }
+                field {
+                  ... on ProjectV2FieldCommon {
+                    name
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldRepositoryValue {
+                repository {
+                  nameWithOwner
+                }
+                field {
+                  ... on ProjectV2FieldCommon {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export function defaultFindNextOptions(overrides = {}) {
+  return {
+    eligibleStatuses: [...DEFAULT_ELIGIBLE_STATUSES],
+    excludedStatuses: [...DEFAULT_EXCLUDED_STATUSES],
+    pageSize: DEFAULT_PAGE_SIZE,
+    maxPages: DEFAULT_MAX_PAGES,
+    ...overrides
+  };
+}
+
+export function normalizeProjectItem(node) {
+  const content = node.content ?? {};
+  const fieldValues = node.fieldValues?.nodes ?? [];
+  const singleSelectValues = new Map();
+  const userValues = new Map();
+  let repository = content.repository?.nameWithOwner ?? null;
+
+  for (const fieldValue of fieldValues) {
+    const fieldName = fieldValue.field?.name;
+    if (!fieldName) {
+      continue;
+    }
+
+    if (fieldValue.__typename === "ProjectV2ItemFieldSingleSelectValue") {
+      singleSelectValues.set(fieldName, fieldValue.name ?? null);
+    }
+
+    if (fieldValue.__typename === "ProjectV2ItemFieldUserValue") {
+      userValues.set(
+        fieldName,
+        (fieldValue.users?.nodes ?? [])
+          .map((user) => user.login)
+          .filter(Boolean)
+      );
+    }
+
+    if (fieldValue.__typename === "ProjectV2ItemFieldRepositoryValue" && fieldValue.repository?.nameWithOwner) {
+      repository = fieldValue.repository.nameWithOwner;
+    }
+  }
+
+  return {
+    itemId: node.id,
+    contentType: content.__typename ?? "Unknown",
+    number: content.number ?? null,
+    title: content.title ?? null,
+    url: content.url ?? null,
+    repository,
+    status: singleSelectValues.get("Status") ?? null,
+    priority: singleSelectValues.get("Priority") ?? null,
+    projectAssignees: userValues.get("Assignees") ?? [],
+    contentAssignees: (content.assignees?.nodes ?? [])
+      .map((assignee) => assignee.login)
+      .filter(Boolean)
+  };
+}
+
+export function getAssignees(item) {
+  return [...new Set([...(item.projectAssignees ?? []), ...(item.contentAssignees ?? [])])];
+}
+
+export function isEligibleProjectItem(item, options = {}) {
+  const normalizedOptions = defaultFindNextOptions(options);
+  const assignees = getAssignees(item);
+
+  if (!item.title || !item.status || normalizedOptions.excludedStatuses.includes(item.status)) {
+    return false;
+  }
+
+  if (normalizedOptions.eligibleStatuses.length > 0 && !normalizedOptions.eligibleStatuses.includes(item.status)) {
+    return false;
+  }
+
+  if (normalizedOptions.selfLogin && assignees.length > 0 && !assignees.includes(normalizedOptions.selfLogin)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function selectNextEligibleItem(items, options = {}) {
+  const normalizedOptions = defaultFindNextOptions(options);
+  const eligible = items
+    .filter((item) => isEligibleProjectItem(item, normalizedOptions))
+    .sort((left, right) => compareEligibleItems(left, right, normalizedOptions));
+
+  return eligible[0] ?? null;
+}
+
+export function summarizeFindNextResult(response, options = {}) {
+  const normalizedOptions = defaultFindNextOptions(options);
+  const project = response?.data?.organization?.projectV2;
+  if (!project) {
+    throw new Error("Project not found in GraphQL response.");
+  }
+
+  const items = (project.items?.nodes ?? []).map(normalizeProjectItem);
+  return {
+    projectId: project.id,
+    projectTitle: project.title,
+    items,
+    candidate: selectNextEligibleItem(items, normalizedOptions),
+    pageInfo: project.items?.pageInfo ?? { hasNextPage: false, endCursor: null }
+  };
+}
+
+export function parseFieldMapResponse(response) {
+  const project = response?.project ?? response;
+  const fields = project.fields ?? [];
+  const statusField = fields.find((field) => field.name === "Status");
+  if (!statusField) {
+    throw new Error("Project is missing a Status field.");
+  }
+
+  const statuses = Object.fromEntries((statusField.options ?? []).map((option) => [option.name, option.id]));
+  return {
+    projectId: project.id,
+    projectNumber: project.number,
+    projectTitle: project.title,
+    statusFieldId: statusField.id,
+    statuses
+  };
+}
+
+function compareEligibleItems(left, right, options) {
+  const priorityDelta = priorityRank(left.priority) - priorityRank(right.priority);
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  const workTypeDelta = workTypeRank(left.title) - workTypeRank(right.title);
+  if (workTypeDelta !== 0) {
+    return workTypeDelta;
+  }
+
+  const statusDelta = statusRank(left.status, options.eligibleStatuses) - statusRank(right.status, options.eligibleStatuses);
+  if (statusDelta !== 0) {
+    return statusDelta;
+  }
+
+  if (left.number != null && right.number != null) {
+    return left.number - right.number;
+  }
+
+  return (left.title ?? "").localeCompare(right.title ?? "");
+}
+
+function priorityRank(priority) {
+  switch (priority) {
+    case "P0":
+      return 0;
+    case "P1":
+      return 1;
+    case "P2":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function statusRank(status, eligibleStatuses) {
+  const index = eligibleStatuses.indexOf(status);
+  return index === -1 ? eligibleStatuses.length : index;
+}
+
+function workTypeRank(title) {
+  if (title?.startsWith("[TASK]")) {
+    return 0;
+  }
+  if (title?.startsWith("[STORY]")) {
+    return 1;
+  }
+  if (title?.startsWith("[FEATURE]")) {
+    return 2;
+  }
+  if (title?.startsWith("[EPIC]")) {
+    return 3;
+  }
+  return 4;
+}

--- a/tools/project-board/test/cli.test.mjs
+++ b/tools/project-board/test/cli.test.mjs
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const cliPath = path.resolve("tools/project-board/cli.mjs");
+
+test("CLI prints help output", () => {
+  const result = runCli(["--help"]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage: npm run project:board/);
+});
+
+test("CLI reports unknown commands", () => {
+  const result = runCli(["wat"]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unknown command: wat/);
+});
+
+test("find-next uses gh responses and returns a candidate", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "find-next",
+      "--owner",
+      "Plasius-LTD",
+      "--project-number",
+      "1",
+      "--self-login",
+      "zephod111r"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.candidate.number, 524);
+    assert.equal(parsed.candidate.priority, "P0");
+    assert.equal(parsed.pagesScanned, 1);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("fields prints project status ids", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "fields",
+      "--owner",
+      "Plasius-LTD",
+      "--project-number",
+      "1"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.projectId, "project-1");
+    assert.equal(parsed.statuses["In progress"], "progress-id");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("find-item locates a linked issue by repo and number", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "find-item",
+      "--owner",
+      "Plasius-LTD",
+      "--project-number",
+      "1",
+      "--repo",
+      "Plasius-LTD/road-map",
+      "--issue-number",
+      "524"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.item.number, 524);
+    assert.equal(parsed.item.itemId, "item-2");
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("set-status resolves field ids then edits the project item", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath, logPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "set-status",
+      "--owner",
+      "Plasius-LTD",
+      "--project-number",
+      "1",
+      "--item-id",
+      "item-2",
+      "--status",
+      "In progress"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath,
+        FAKE_GH_LOG: logPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const log = await readLog(logPath);
+    assert.ok(log.some((entry) => entry[0] === "project" && entry[1] === "item-edit" && entry.includes("progress-id")));
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("claim assigns the issue and updates project status", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath, logPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "claim",
+      "--owner",
+      "Plasius-LTD",
+      "--project-number",
+      "1",
+      "--item-id",
+      "item-2",
+      "--status",
+      "In progress",
+      "--repo",
+      "Plasius-LTD/road-map",
+      "--issue-number",
+      "524",
+      "--assignee",
+      "zephod111r"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath,
+        FAKE_GH_LOG: logPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const log = await readLog(logPath);
+    assert.ok(log.some((entry) => entry[0] === "api" && entry[1] === "repos/Plasius-LTD/road-map/issues/524" && entry.includes("assignees[]=zephod111r")));
+    assert.ok(log.some((entry) => entry[0] === "project" && entry[1] === "item-edit"));
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("comment posts an issue comment through REST", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "project-board-cli-"));
+
+  try {
+    const { fakeGhPath, logPath } = await createFakeGh(workspace);
+    const result = runCli([
+      "comment",
+      "--repo",
+      "Plasius-LTD/road-map",
+      "--issue-number",
+      "524",
+      "--body",
+      "evidence"
+    ], {
+      env: {
+        PLASIUS_GH_BIN: fakeGhPath,
+        FAKE_GH_LOG: logPath
+      }
+    });
+
+    assert.equal(result.status, 0);
+    const log = await readLog(logPath);
+    assert.ok(log.some((entry) => entry[0] === "api" && entry[1] === "repos/Plasius-LTD/road-map/issues/524/comments" && entry.includes("body=evidence")));
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("set-status validates required arguments", () => {
+  const result = runCli([
+    "set-status",
+    "--owner",
+    "Plasius-LTD",
+    "--project-number",
+    "1"
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--item-id is required/);
+});
+
+function runCli(args, overrides = {}) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: path.dirname(cliPath),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...(overrides.env ?? {})
+    }
+  });
+}
+
+async function createFakeGh(workspace) {
+  await mkdir(workspace, { recursive: true });
+  const fakeGhPath = path.join(workspace, "gh");
+  const logPath = path.join(workspace, "gh.log");
+  await writeFile(fakeGhPath, `#!/usr/bin/env node
+const { appendFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.FAKE_GH_LOG) {
+  appendFileSync(process.env.FAKE_GH_LOG, JSON.stringify(args) + "\\n", "utf8");
+}
+if (args[0] === "project" && args[1] === "list") {
+  process.stdout.write(JSON.stringify({
+    projects: [{ id: "project-1", number: 1, title: "Plasius-LTD-site" }]
+  }));
+  process.exit(0);
+}
+if (args[0] === "project" && args[1] === "field-list") {
+  process.stdout.write(JSON.stringify({
+    fields: [{
+      id: "status-field",
+      name: "Status",
+      options: [
+        { id: "backlog-id", name: "Backlog" },
+        { id: "progress-id", name: "In progress" },
+        { id: "done-id", name: "Done" }
+      ]
+    }]
+  }));
+  process.exit(0);
+}
+if (args[0] === "project" && args[1] === "item-edit") {
+  process.stdout.write(JSON.stringify({ ok: true }));
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "graphql") {
+  process.stdout.write(JSON.stringify({
+    data: {
+      organization: {
+        projectV2: {
+          id: "project-1",
+          title: "Plasius-LTD-site",
+          items: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: "cursor-1"
+            },
+            nodes: [{
+              id: "item-2",
+              content: {
+                __typename: "Issue",
+                number: 524,
+                title: "[TASK] Unblock Plasius-LTD-site backlog automation from GitHub GraphQL rate exhaustion",
+                url: "https://github.com/Plasius-LTD/road-map/issues/524",
+                repository: {
+                  nameWithOwner: "Plasius-LTD/road-map"
+                },
+                assignees: {
+                  nodes: [{ login: "zephod111r" }]
+                }
+              },
+              fieldValues: {
+                nodes: [
+                  {
+                    __typename: "ProjectV2ItemFieldSingleSelectValue",
+                    name: "Backlog",
+                    field: { name: "Status" }
+                  },
+                  {
+                    __typename: "ProjectV2ItemFieldSingleSelectValue",
+                    name: "P0",
+                    field: { name: "Priority" }
+                  }
+                ]
+              }
+            }]
+          }
+        }
+      }
+    }
+  }));
+  process.exit(0);
+}
+if (args[0] === "api") {
+  process.stdout.write(JSON.stringify({ ok: true }));
+  process.exit(0);
+}
+process.stderr.write("unexpected gh invocation: " + JSON.stringify(args));
+process.exit(1);
+`, "utf8");
+  await chmod(fakeGhPath, 0o755);
+  return { fakeGhPath, logPath };
+}
+
+async function readLog(logPath) {
+  const content = await readFile(logPath, "utf8");
+  return content
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/tools/project-board/test/index.test.mjs
+++ b/tools/project-board/test/index.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isEligibleProjectItem,
+  normalizeProjectItem,
+  parseFieldMapResponse,
+  selectNextEligibleItem,
+  summarizeFindNextResult
+} from "../index.mjs";
+
+test("normalizeProjectItem merges content and project field values", () => {
+  const item = normalizeProjectItem({
+    id: "item-1",
+    content: {
+      __typename: "Issue",
+      number: 524,
+      title: "[TASK] Unblock GraphQL paging",
+      url: "https://example.test/issues/524",
+      repository: {
+        nameWithOwner: "Plasius-LTD/road-map"
+      },
+      assignees: {
+        nodes: [{ login: "zephod111r" }]
+      }
+    },
+    fieldValues: {
+      nodes: [
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "Ready",
+          field: { name: "Status" }
+        },
+        {
+          __typename: "ProjectV2ItemFieldSingleSelectValue",
+          name: "P0",
+          field: { name: "Priority" }
+        },
+        {
+          __typename: "ProjectV2ItemFieldUserValue",
+          users: {
+            nodes: [{ login: "teammate" }]
+          },
+          field: { name: "Assignees" }
+        }
+      ]
+    }
+  });
+
+  assert.deepEqual(item, {
+    itemId: "item-1",
+    contentType: "Issue",
+    number: 524,
+    title: "[TASK] Unblock GraphQL paging",
+    url: "https://example.test/issues/524",
+    repository: "Plasius-LTD/road-map",
+    status: "Ready",
+    priority: "P0",
+    projectAssignees: ["teammate"],
+    contentAssignees: ["zephod111r"]
+  });
+});
+
+test("isEligibleProjectItem excludes done and foreign-assigned items", () => {
+  assert.equal(isEligibleProjectItem({
+    title: "[TASK] Done item",
+    status: "Done",
+    projectAssignees: [],
+    contentAssignees: []
+  }, { selfLogin: "zephod111r" }), false);
+
+  assert.equal(isEligibleProjectItem({
+    title: "[TASK] Other owner's item",
+    status: "Ready",
+    projectAssignees: ["teammate"],
+    contentAssignees: []
+  }, { selfLogin: "zephod111r" }), false);
+
+  assert.equal(isEligibleProjectItem({
+    title: "[TASK] My item",
+    status: "Ready",
+    projectAssignees: [],
+    contentAssignees: ["zephod111r"]
+  }, { selfLogin: "zephod111r" }), true);
+});
+
+test("selectNextEligibleItem prefers priority, then granular work type", () => {
+  const selection = selectNextEligibleItem([
+    {
+      title: "[FEATURE] Later feature",
+      status: "Ready",
+      priority: "P1",
+      number: 900,
+      projectAssignees: [],
+      contentAssignees: []
+    },
+    {
+      title: "[TASK] Important task",
+      status: "Backlog",
+      priority: "P0",
+      number: 901,
+      projectAssignees: [],
+      contentAssignees: []
+    },
+    {
+      title: "[STORY] My story",
+      status: "Ready",
+      priority: "P0",
+      number: 902,
+      projectAssignees: ["zephod111r"],
+      contentAssignees: []
+    }
+  ], { selfLogin: "zephod111r" });
+
+  assert.equal(selection.title, "[TASK] Important task");
+});
+
+test("summarizeFindNextResult returns the next candidate and cursor", () => {
+  const summary = summarizeFindNextResult({
+    data: {
+      organization: {
+        projectV2: {
+          id: "project-1",
+          title: "Plasius-LTD-site",
+          items: {
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: "cursor-2"
+            },
+            nodes: [
+              {
+                id: "item-1",
+                content: {
+                  __typename: "Issue",
+                  number: 100,
+                  title: "[FEATURE] Already owned elsewhere",
+                  repository: { nameWithOwner: "Plasius-LTD/plasius-ltd-site" },
+                  assignees: { nodes: [{ login: "another-user" }] }
+                },
+                fieldValues: {
+                  nodes: [
+                    {
+                      __typename: "ProjectV2ItemFieldSingleSelectValue",
+                      name: "Ready",
+                      field: { name: "Status" }
+                    }
+                  ]
+                }
+              },
+              {
+                id: "item-2",
+                content: {
+                  __typename: "Issue",
+                  number: 101,
+                  title: "[TASK] Next action",
+                  repository: { nameWithOwner: "Plasius-LTD/road-map" },
+                  assignees: { nodes: [] }
+                },
+                fieldValues: {
+                  nodes: [
+                    {
+                      __typename: "ProjectV2ItemFieldSingleSelectValue",
+                      name: "Backlog",
+                      field: { name: "Status" }
+                    },
+                    {
+                      __typename: "ProjectV2ItemFieldSingleSelectValue",
+                      name: "P1",
+                      field: { name: "Priority" }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }, {
+    selfLogin: "zephod111r"
+  });
+
+  assert.equal(summary.projectId, "project-1");
+  assert.equal(summary.candidate.title, "[TASK] Next action");
+  assert.equal(summary.pageInfo.endCursor, "cursor-2");
+});
+
+test("parseFieldMapResponse extracts status option ids", () => {
+  const fields = parseFieldMapResponse({
+    id: "project-1",
+    number: 1,
+    title: "Plasius-LTD-site",
+    fields: [
+      {
+        id: "status-field",
+        name: "Status",
+        options: [
+          { id: "ready-id", name: "Ready" },
+          { id: "progress-id", name: "In progress" }
+        ]
+      }
+    ]
+  });
+
+  assert.deepEqual(fields, {
+    projectId: "project-1",
+    projectNumber: 1,
+    projectTitle: "Plasius-LTD-site",
+    statusFieldId: "status-field",
+    statuses: {
+      Ready: "ready-id",
+      "In progress": "progress-id"
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a low-cost `project:board` CLI for minimal Project discovery, targeted status updates, and REST-backed comments
- add tests covering normalization, selection, and command paths with fake `gh` wiring
- document the cursor-checkpoint strategy in a runbook and ADR

## Validation
- npm run build
- npm test
- npm run typecheck
- npm run test:coverage