### PR TITLE
ci: refine Codecov and runner policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '"ubuntu-latest"' || vars.CI_RUNNER_LABELS || '["self-hosted","Linux","X64"]') }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Remove Codecov uploads from CI, keep release uploads non-blocking when quota-limited, and prefer self-hosted runners for trusted workflow jobs.